### PR TITLE
Update AGP and Kotlin for API 35

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,6 +2,22 @@ plugins {
     `kotlin-dsl`
 }
 
+kotlin {
+    jvmToolchain(21)
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(17)
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "17"
+}
+
 gradlePlugin {
     plugins {
         register("AndroidCoreLibraryPlugin") {
@@ -18,8 +34,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:7.2.2")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
+    implementation("com.android.tools.build:gradle:8.4.0")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25")
     implementation("com.google.dagger:hilt-android-gradle-plugin:2.44.2")
 
 }

--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -3,9 +3,9 @@
  */
 object AppConfig {
     const val minSdk = 21
-    const val targetSdk = 33
-    const val compileSdk = 33
+    const val targetSdk = 35
+    const val compileSdk = 35
     const val versionCode = 1
     const val VersionName = "1.0.0"
-    const val KotlinCompilerExtension="1.4.2"
+    const val KotlinCompilerExtension="1.5.15"
 }

--- a/buildSrc/src/main/java/plugin/android-common.gradle.kts
+++ b/buildSrc/src/main/java/plugin/android-common.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 }
 
 android {
+    namespace = "com.puskal." + project.name.replace("-", "")
     compileSdk = AppConfig.compileSdk
     defaultConfig {
         minSdk = AppConfig.minSdk

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Mar 14 16:25:09 NPT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- bump Android Gradle Plugin to `8.4.0`
- update Kotlin to `1.9.25`
- update Gradle wrapper to `8.6`
- set compile/target sdk to 35
- update Compose compiler extension version
- generate namespace automatically for library modules

## Testing
- `./gradlew build --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a462eb01c832c9dd3726a87f73a37