### PR TITLE
Add SessionManager utility

### DIFF
--- a/core/src/main/java/com/puskal/core/utils/SessionManager.kt
+++ b/core/src/main/java/com/puskal/core/utils/SessionManager.kt
@@ -1,0 +1,28 @@
+package com.puskal.core.utils
+
+/**
+ * Created by Puskal Khadka on 11/20/2023.
+ */
+
+object SessionManager {
+    var isLoggedIn: Boolean = false
+        private set
+    var email: String? = null
+        private set
+
+    /**
+     * Mark the session as logged in with the provided [email].
+     */
+    fun logIn(email: String) {
+        this.email = email
+        isLoggedIn = true
+    }
+
+    /**
+     * Clear the session and mark the user as logged out.
+     */
+    fun logOut() {
+        email = null
+        isLoggedIn = false
+    }
+}


### PR DESCRIPTION
## Summary
- add `SessionManager` object to track login state

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a53c01d20832c9a5dc6d79d1ef7c3