### PR TITLE
Fix compile error after Material3 update

### DIFF
--- a/common/composable/src/main/java/com/puskal/composable/ContentSearchBar.kt
+++ b/common/composable/src/main/java/com/puskal/composable/ContentSearchBar.kt
@@ -35,11 +35,14 @@ fun ContentSearchBar(
     marginHorizontal: Dp = 16.dp,
     marginTop: Dp = 8.dp
 ) {
-    val textFieldColors = TextFieldDefaults.outlinedTextFieldColors(
+    val textFieldColors = OutlinedTextFieldDefaults.colors(
+        focusedTextColor = Color.White,
+        unfocusedTextColor = Color.White,
+        focusedPlaceholderColor = Color.White,
+        unfocusedPlaceholderColor = Color.White,
+        focusedContainerColor = Color.Transparent,
+        unfocusedContainerColor = Color.Transparent,
         unfocusedBorderColor = OverlayWhiteColor,
-        containerColor = Color.Transparent,
-        textColor = Color.White,
-        placeholderColor = Color.White
     )
     val shape = RoundedCornerShape(8.dp)
     val interactionSource = remember {

--- a/feature/commentlisting/src/main/java/com/puskal/commentlisting/CommentListScreen.kt
+++ b/feature/commentlisting/src/main/java/com/puskal/commentlisting/CommentListScreen.kt
@@ -224,8 +224,9 @@ fun CommentUserField() {
                 placeholder = {
                     Text(text = stringResource(R.string.add_comment))
                 },
-                colors = TextFieldDefaults.outlinedTextFieldColors(
-                    containerColor = GrayMainColor,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedContainerColor = GrayMainColor,
+                    unfocusedContainerColor = GrayMainColor,
                     unfocusedBorderColor = Color.Transparent
                 ),
                 modifier = Modifier.height(46.dp),

--- a/feature/creatorprofile/src/main/java/com/puskal/creatorprofile/screen/creatorvideo/CreatorVideoPagerScreen.kt
+++ b/feature/creatorprofile/src/main/java/com/puskal/creatorprofile/screen/creatorvideo/CreatorVideoPagerScreen.kt
@@ -73,8 +73,9 @@ fun CreatorVideoPagerScreen(
                     placeholder = {
                         Text(text = stringResource(R.string.add_comment), color = SubTextColor)
                     },
-                    colors = TextFieldDefaults.outlinedTextFieldColors(
-                        containerColor = Color.Black,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedContainerColor = Color.Black,
+                        unfocusedContainerColor = Color.Black,
                         unfocusedBorderColor = Color.Transparent
                     ),
                     modifier = Modifier


### PR DESCRIPTION
## Summary
- replace deprecated `TextFieldDefaults.outlinedTextFieldColors` with `OutlinedTextFieldDefaults.colors`

## Testing
- `./gradlew help`
- `./gradlew :common:composable:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5529cfa0832ca2371cfb5b2db1c1