### PR TITLE
Check session state in screens

### DIFF
--- a/feature/friends/src/main/java/com/puskal/friends/FriendsScreen.kt
+++ b/feature/friends/src/main/java/com/puskal/friends/FriendsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
+import com.puskal.core.utils.SessionManager
 import com.puskal.composable.TopBar
 import com.puskal.core.DestinationRoute.AUTHENTICATION_ROUTE
 import com.puskal.theme.R
@@ -29,15 +30,19 @@ fun FriendsScreen(navController: NavController) {
                 .padding(it)
                 .fillMaxSize()
         ) {
-
+            if (SessionManager.isLoggedIn) {
+                Text(text = "Logged in as ${SessionManager.email}")
+            }
         }
     }
 
-    LaunchedEffect(key1 = Unit) {
-        //for now:- (default guest user) redirect to auth
-        navController.apply {
-            popBackStack()
-            navController.navigate(AUTHENTICATION_ROUTE)
+    if (!SessionManager.isLoggedIn) {
+        LaunchedEffect(key1 = Unit) {
+            //for now:- (default guest user) redirect to auth
+            navController.apply {
+                popBackStack()
+                navController.navigate(AUTHENTICATION_ROUTE)
+            }
         }
     }
 }

--- a/feature/inbox/src/main/java/com/puskal/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/puskal/inbox/InboxScreen.kt
@@ -15,6 +15,7 @@ import androidx.navigation.NavController
 import com.puskal.composable.CustomButton
 import com.puskal.composable.TopBar
 import com.puskal.core.DestinationRoute.AUTHENTICATION_ROUTE
+import com.puskal.core.utils.SessionManager
 import com.puskal.theme.R
 import com.puskal.theme.SubTextColor
 
@@ -33,8 +34,12 @@ fun InboxScreen(navController: NavController) {
                 .padding(it)
                 .fillMaxSize()
         ) {
-            UnAuthorizedInboxScreen {
-                navController.navigate(AUTHENTICATION_ROUTE)
+            if (SessionManager.isLoggedIn) {
+                Text(text = "Logged in as ${SessionManager.email}")
+            } else {
+                UnAuthorizedInboxScreen {
+                    navController.navigate(AUTHENTICATION_ROUTE)
+                }
             }
         }
     }

--- a/feature/myprofile/src/main/java/com/puskal/myprofile/MyProfileScreen.kt
+++ b/feature/myprofile/src/main/java/com/puskal/myprofile/MyProfileScreen.kt
@@ -14,6 +14,7 @@ import com.puskal.composable.CustomButton
 import com.puskal.composable.TopBar
 import com.puskal.core.DestinationRoute
 import com.puskal.core.DestinationRoute.SETTING_ROUTE
+import com.puskal.core.utils.SessionManager
 import com.puskal.theme.R
 import com.puskal.theme.SubTextColor
 
@@ -42,8 +43,12 @@ fun MyProfileScreen(navController: NavController) {
                 .padding(it)
                 .fillMaxSize()
         ) {
-            UnAuthorizedInboxScreen {
-                navController.navigate(DestinationRoute.AUTHENTICATION_ROUTE)
+            if (SessionManager.isLoggedIn) {
+                Text(text = "Logged in as ${SessionManager.email}")
+            } else {
+                UnAuthorizedInboxScreen {
+                    navController.navigate(DestinationRoute.AUTHENTICATION_ROUTE)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- show a simple logged-in placeholder on the Friends, Inbox and Profile screens
- keep existing unauthenticated behavior otherwise

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_686a55bfc8b4832cb2b133b9a7bfcf06