### PR TITLE
Implement password login flow

### DIFF
--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="email_username">Email / Username</string>
     <string name="phone_number">Phone number</string>
     <string name="enter_email_address_or_username">Enter email address or username</string>
+    <string name="password">Password</string>
     <string name="next">Next</string>
     <string name="by_continuing_you_agree">By continuing, you agree to our </string>
     <string name="and_acknowledge_that_you_have">and acknowledge that you have read our</string>

--- a/core/src/main/java/com/puskal/core/SessionManager.kt
+++ b/core/src/main/java/com/puskal/core/SessionManager.kt
@@ -1,0 +1,9 @@
+package com.puskal.core
+
+/**
+ * Simple session holder for demo purposes.
+ */
+object SessionManager {
+    var isLoggedIn: Boolean = false
+    var email: String? = null
+}

--- a/feature/loginwithemailphone/src/main/java/com/puskal/loginwithemailphone/LoginWithEmailPhoneContract.kt
+++ b/feature/loginwithemailphone/src/main/java/com/puskal/loginwithemailphone/LoginWithEmailPhoneContract.kt
@@ -15,6 +15,7 @@ sealed class LoginEmailPhoneEvent {
     data class EventPageChange(val settledPage: Int) : LoginEmailPhoneEvent()
     data class OnChangePhoneNumber(val newValue: String) : LoginEmailPhoneEvent()
     data class OnChangeEmailEntry(val newValue: String) : LoginEmailPhoneEvent()
+    data class OnChangePassword(val newValue: String) : LoginEmailPhoneEvent()
 }
 
 

--- a/feature/loginwithemailphone/src/main/java/com/puskal/loginwithemailphone/LoginWithEmailPhoneScreen.kt
+++ b/feature/loginwithemailphone/src/main/java/com/puskal/loginwithemailphone/LoginWithEmailPhoneScreen.kt
@@ -57,14 +57,17 @@ fun LoginWithEmailPhoneScreen(
                 .fillMaxSize()
                 .padding(it)
         ) {
-            LoginPager(viewModel)
+            LoginPager(navController, viewModel)
         }
     }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-internal fun LoginPager(viewModel: LoginWithEmailPhoneViewModel) {
+internal fun LoginPager(
+    navController: NavController,
+    viewModel: LoginWithEmailPhoneViewModel
+) {
     val pagerState = rememberPagerState()
     val pages = LoginPages.values().asList()
     val coroutineScope = rememberCoroutineScope()
@@ -113,7 +116,7 @@ internal fun LoginPager(viewModel: LoginWithEmailPhoneViewModel) {
 
         when (page) {
             0 -> PhoneTabScreen(viewModel)
-            1 -> EmailUsernameTabScreen(viewModel)
+            1 -> EmailUsernameTabScreen(navController, viewModel)
         }
     }
 }

--- a/feature/loginwithemailphone/src/main/java/com/puskal/loginwithemailphone/LoginWithEmailPhoneViewModel.kt
+++ b/feature/loginwithemailphone/src/main/java/com/puskal/loginwithemailphone/LoginWithEmailPhoneViewModel.kt
@@ -26,6 +26,9 @@ class LoginWithEmailPhoneViewModel @Inject constructor(
     private val _email = MutableStateFlow<Pair<String, String?>>(Pair("", null))
     val email = _email.asStateFlow()
 
+    private val _password = MutableStateFlow("")
+    val password = _password.asStateFlow()
+
 
     override fun onTriggerEvent(event: LoginEmailPhoneEvent) {
         when (event) {
@@ -34,6 +37,7 @@ class LoginWithEmailPhoneViewModel @Inject constructor(
                 _email.value.copy(first = event.newValue)
             is LoginEmailPhoneEvent.OnChangePhoneNumber -> _phoneNumber.value =
                 _phoneNumber.value.copy(first = event.newValue)
+            is LoginEmailPhoneEvent.OnChangePassword -> _password.value = event.newValue
         }
     }
 

--- a/feature/loginwithemailphone/src/main/java/com/puskal/loginwithemailphone/tabs/EmailUsernameTabScreen.kt
+++ b/feature/loginwithemailphone/src/main/java/com/puskal/loginwithemailphone/tabs/EmailUsernameTabScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.ui.text.*
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import com.puskal.composable.CustomButton
 import com.puskal.core.AppContract
+import com.puskal.core.SessionManager
 import com.puskal.core.extension.Space
 import com.puskal.loginwithemailphone.LoginEmailPhoneEvent
 import com.puskal.loginwithemailphone.LoginWithEmailPhoneViewModel
@@ -35,8 +37,12 @@ import com.puskal.theme.R
  */
 
 @Composable
-fun EmailUsernameTabScreen(viewModel: LoginWithEmailPhoneViewModel) {
+fun EmailUsernameTabScreen(
+    navController: NavController,
+    viewModel: LoginWithEmailPhoneViewModel
+) {
     val email by viewModel.email.collectAsState()
+    val password by viewModel.password.collectAsState()
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -49,14 +55,18 @@ fun EmailUsernameTabScreen(viewModel: LoginWithEmailPhoneViewModel) {
         ) {
             EmailField(email, viewModel)
             8.dp.Space()
+            PasswordField(password, viewModel)
+            8.dp.Space()
             PrivacyPolicyText {}
             16.dp.Space()
             CustomButton(
                 buttonText = stringResource(id = R.string.next),
                 modifier = Modifier.fillMaxWidth(),
-                isEnabled = email.first.isNotEmpty()
+                isEnabled = email.first.isNotEmpty() && password.isNotEmpty()
             ) {
-
+                SessionManager.isLoggedIn = true
+                SessionManager.email = email.first
+                navController.popBackStack()
             }
         }
 
@@ -122,6 +132,33 @@ fun EmailField(email: Pair<String, String?>, viewModel: LoginWithEmailPhoneViewM
             focusRequester.requestFocus()
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PasswordField(password: String, viewModel: LoginWithEmailPhoneViewModel) {
+    TextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = password,
+        textStyle = MaterialTheme.typography.labelLarge,
+        onValueChange = {
+            viewModel.onTriggerEvent(LoginEmailPhoneEvent.OnChangePassword(it))
+        },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+        singleLine = true,
+        colors = TextFieldDefaults.textFieldColors(
+            containerColor = Color.Transparent,
+            focusedIndicatorColor = SubTextColor,
+            unfocusedIndicatorColor = SubTextColor,
+        ),
+        placeholder = {
+            Text(
+                text = stringResource(id = R.string.password),
+                style = MaterialTheme.typography.labelLarge,
+                color = SubTextColor
+            )
+        }
+    )
 }
 
 


### PR DESCRIPTION
## Summary
- add SessionManager to store login status
- support password entry in login view model
- show password field under email field
- update button action to log user in and pop navigation
- wire new navigation parameter
- add resource string for password

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a53d31f34832c8c3525f22dd79415