### PR TITLE
Update bottom bar for navigation insets

### DIFF
--- a/app/src/main/java/com/puskal/tiktokcompose/component/BottomBar.kt
+++ b/app/src/main/java/com/puskal/tiktokcompose/component/BottomBar.kt
@@ -1,6 +1,8 @@
 package com.puskal.tiktokcompose.component
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -28,6 +30,7 @@ fun BottomBar(
         modifier = Modifier
             .height(52.dp)
             .shadow(elevation = 16.dp)
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom))
             .padding(top = 2.dp)
     ) {
         BottomBarDestination.values().asList().forEach {


### PR DESCRIPTION
## Summary
- pad the bottom navigation bar using `WindowInsets.safeDrawing`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6559f868832cb4e78a00a61a3081