### PR TITLE
Add demo message for logged-in users

### DIFF
--- a/common/composable/src/main/java/com/puskal/composable/LoggedInInfo.kt
+++ b/common/composable/src/main/java/com/puskal/composable/LoggedInInfo.kt
@@ -1,0 +1,43 @@
+package com.puskal.composable
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.puskal.theme.R
+import com.puskal.theme.SubTextColor
+
+/**
+ * Simple message shown when user is logged in.
+ */
+@Composable
+fun LoggedInInfo(email: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxHeight(0.8f)
+            .fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(20.dp, alignment = Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_verified),
+            contentDescription = null,
+            modifier = Modifier.size(68.dp)
+        )
+        Text(
+            text = stringResource(id = R.string.logged_in_as, email),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = stringResource(id = R.string.demo_video_compositor),
+            color = SubTextColor,
+            style = MaterialTheme.typography.labelMedium
+        )
+    }
+}

--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -102,5 +102,7 @@
     <string name="timer">Timer</string>
     <string name="flash">Flash</string>
     <string name="upload_photos">Upload photos</string>
+    <string name="logged_in_as">Logged in as %1$s</string>
+    <string name="demo_video_compositor">This is a demo for video compositor</string>
 
 </resources>

--- a/feature/friends/src/main/java/com/puskal/friends/FriendsScreen.kt
+++ b/feature/friends/src/main/java/com/puskal/friends/FriendsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import com.puskal.composable.LoggedInInfo
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import com.puskal.core.SessionManager
@@ -31,7 +32,7 @@ fun FriendsScreen(navController: NavController) {
                 .fillMaxSize()
         ) {
             if (SessionManager.isLoggedIn) {
-                Text(text = "Logged in as ${SessionManager.email}")
+                LoggedInInfo(SessionManager.email ?: "")
             }
         }
     }

--- a/feature/inbox/src/main/java/com/puskal/inbox/InboxScreen.kt
+++ b/feature/inbox/src/main/java/com/puskal/inbox/InboxScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.puskal.composable.CustomButton
+import com.puskal.composable.LoggedInInfo
 import com.puskal.composable.TopBar
 import com.puskal.core.DestinationRoute.AUTHENTICATION_ROUTE
 import com.puskal.core.SessionManager
@@ -35,7 +36,7 @@ fun InboxScreen(navController: NavController) {
                 .fillMaxSize()
         ) {
             if (SessionManager.isLoggedIn) {
-                Text(text = "Logged in as ${SessionManager.email}")
+                LoggedInInfo(SessionManager.email ?: "")
             } else {
                 UnAuthorizedInboxScreen {
                     navController.navigate(AUTHENTICATION_ROUTE)

--- a/feature/myprofile/src/main/java/com/puskal/myprofile/MyProfileScreen.kt
+++ b/feature/myprofile/src/main/java/com/puskal/myprofile/MyProfileScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.puskal.composable.CustomButton
+import com.puskal.composable.LoggedInInfo
 import com.puskal.composable.TopBar
 import com.puskal.core.DestinationRoute
 import com.puskal.core.DestinationRoute.SETTING_ROUTE
@@ -44,7 +45,7 @@ fun MyProfileScreen(navController: NavController) {
                 .fillMaxSize()
         ) {
             if (SessionManager.isLoggedIn) {
-                Text(text = "Logged in as ${SessionManager.email}")
+                LoggedInInfo(SessionManager.email ?: "")
             } else {
                 UnAuthorizedInboxScreen {
                     navController.navigate(DestinationRoute.AUTHENTICATION_ROUTE)


### PR DESCRIPTION
## Summary
- show a "logged in" message on profile, inbox, and friends screens
- implement `LoggedInInfo` composable for a nicer display
- add strings for the logged-in message

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a64d622ac832c81c779f363536757