### PR TITLE
Fix compile error in CameraGlPreviewView

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/gl/CameraGlPreviewView.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/gl/CameraGlPreviewView.kt
@@ -108,7 +108,7 @@ class CameraGlPreviewView(context: Context) : TextureView(context), TextureView.
         previewFilter?.setup()
         glFilter.setup()
         surfaceTextureWrapper!!.setOnFrameAvailableListener {
-            this@CameraGlPreviewView.invalidate()
+            drawFrame()
         }
     }
 
@@ -125,10 +125,11 @@ class CameraGlPreviewView(context: Context) : TextureView(context), TextureView.
         return true
     }
 
-    override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {}
+    override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {
+        drawFrame()
+    }
 
-    override fun onDraw(canvas: Canvas) {
-        super.onDraw(canvas)
+    private fun drawFrame() {
         val wrapper = surfaceTextureWrapper ?: return
         wrapper.updateTexImage()
         wrapper.getTransformMatrix(stMatrix)


### PR DESCRIPTION
## Summary
- avoid overriding final `onDraw` in `CameraGlPreviewView`
- move GL draw logic to new `drawFrame` method triggered from `onSurfaceTextureUpdated`

## Testing
- `./gradlew :feature:cameramedia:compileDebugKotlin --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6f6a6288832c8dc68ca2fbec67bd