### PR TITLE
Remove redundant plugin version specifications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
 
-    id("com.android.application") version "8.4.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.25" apply false
+    id("com.android.application") apply false
+    id("org.jetbrains.kotlin.android") apply false
     // id("com.google.dagger.hilt.android") version "2.44" apply false
 }


### PR DESCRIPTION
## Summary
- remove explicit version numbers from Gradle plugins

## Testing
- `./gradlew clean` *(fails: Plugin [id: 'io.deepmedia.tools.publisher'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a82c80af4832ca649409a6b3c715c