### PR TITLE
Fix manifest theme merge conflict

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SplashScreenTheme"
+        tools:replace="android:theme"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity


### PR DESCRIPTION
## Summary
- allow the main application's `AndroidManifest.xml` to override library theme

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a93fddf50832c83e1f1808902f7b7