### PR TITLE
Fix missing Material components

### DIFF
--- a/buildSrc/src/main/java/Libraries.kt
+++ b/buildSrc/src/main/java/Libraries.kt
@@ -40,6 +40,7 @@ object Version {
     const val GsonVersion = "2.10.1"
     const val CameraXVersion = "1.3.0-alpha05"
     const val GuavaAndroid="31.0.1-android"
+    const val Material = "1.11.0"
 }
 
 
@@ -68,6 +69,7 @@ object Libraries {
     object Google {
         const val gson = "com.google.code.gson:gson:$GsonVersion"
         const val guava="com.google.guava:guava:$GuavaAndroid"
+        const val material = "com.google.android.material:material:${Version.Material}"
     }
 
     object Accompanist {

--- a/feature/cameracapture/build.gradle.kts
+++ b/feature/cameracapture/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     api("com.google.android.gms:play-services-tasks:17.2.1")
     implementation("androidx.annotation:annotation:1.2.0")
     implementation("com.otaliastudios.opengl:egloo:0.6.1")
+    implementation(Libraries.Google.material)
 }
 
 // Publishing


### PR DESCRIPTION
## Summary
- define Material Components version in buildSrc
- add the material dependency to camera capture module

## Testing
- `./gradlew :app:assembleDebug --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a97a1b0a8832c9357bbece93b1a81