### PR TITLE
Fix video capture in CameraScreen

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -287,12 +287,17 @@ fun CameraPreview(
                             cameraView.mode = Mode.PICTURE
                             cameraView.takePicture()
                         }
-                        CameraCaptureOptions.VIDEO -> {
+                        CameraCaptureOptions.VIDEO,
+                        CameraCaptureOptions.FIFTEEN_SECOND,
+                        CameraCaptureOptions.SIXTY_SECOND -> {
                             cameraView.mode = Mode.VIDEO
                             if (isRecording) {
                                 cameraView.stopVideo()
                             } else {
-                                val file = File(context.filesDir, "video_${'$'}{System.currentTimeMillis()}.mp4")
+                                val file = File(
+                                    context.filesDir,
+                                    "video_${'$'}{System.currentTimeMillis()}.mp4"
+                                )
                                 cameraView.takeVideo(file)
                                 isRecording = true
                             }


### PR DESCRIPTION
## Summary
- ensure video button actually starts recording

## Testing
- `./gradlew test --no-daemon` *(fails: missing JVM)*

------
https://chatgpt.com/codex/tasks/task_e_686a9c247054832cbbfe16bebb5f26bd