### PR TITLE
Add swipe handling documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ This app consist of following modules:
 
 <br/>
 
+## Video Feed Gesture Handling
+For details on how swiping vertically changes pages in the feed, refer to
+[docs/video_feed_swipe_analysis.md](docs/video_feed_swipe_analysis.md).
+
+<br/>
+
 ## Contribution
 You are always welcome to contribute to this project. For contributing, feel free to [create an issue](https://github.com/puskal-khadka/TikTok-Compose/issues/new/choose) or submit a pull request.
 

--- a/docs/video_feed_swipe_analysis.md
+++ b/docs/video_feed_swipe_analysis.md
@@ -1,0 +1,46 @@
+# Video Feed Swipe Handling
+
+This document explains how swipe gestures are detected and how the page changes when navigating vertically through the video feed.
+
+## Gesture Detection
+
+`TiktokVerticalVideoPager` uses Jetpack Compose's `VerticalPager` API to track drag gestures. The pager's state is created via `rememberPagerState`:
+
+```kotlin
+val pagerState = rememberPagerState(
+    initialPage = initialPage ?: 0,
+    pageCount = { videos.size }
+)
+```
+
+Compose's pager automatically registers vertical drag gestures. It calculates the swipe velocity and displacement to decide when to settle on the next or previous page. The `flingBehavior` is configured with `PagerDefaults.flingBehavior` and `PagerSnapDistance.atMost(1)` so that a single fling scrolls at most one page:
+
+```kotlin
+val fling = PagerDefaults.flingBehavior(
+    state = pagerState,
+    pagerSnapDistance = PagerSnapDistance.atMost(1)
+)
+```
+
+## Page Change Logic
+
+`VerticalPager` exposes the `settledPage` property inside `PagerState`. Each `VideoPlayer` checks whether its page index matches `pagerState.settledPage` before creating an `ExoPlayer` instance:
+
+```kotlin
+if (pagerState.settledPage == pageIndex) {
+    val exoPlayer = remember(context) { ExoPlayer.Builder(context).build() }
+    // ...
+}
+```
+
+When the user swipes up or down, `VerticalPager` updates `settledPage` after the scroll animation completes. The currently visible page initializes its video player, while the previous one disposes of its player via `DisposableEffect` when it leaves the screen:
+
+```kotlin
+DisposableEffect(key1 = AndroidView(...)) {
+    onDispose {
+        exoPlayer.release()
+    }
+}
+```
+
+Thus, upward or downward swipes trigger `VerticalPager` to settle on a new page, which in turn starts or stops the correct video playback.


### PR DESCRIPTION
## Summary
- document how vertical swipes change video pages
- link to the new documentation from README

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1eb4e254832cb5c6b31675a2539f