### PR TITLE
Implement choose sound page

### DIFF
--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -105,4 +105,10 @@
     <string name="logged_in_as">Logged in as %1$s</string>
     <string name="demo_video_compositor">This is a demo for video compositor</string>
 
+    <!-- choose sound -->
+    <string name="sounds">Sounds</string>
+    <string name="use_this_sound">Use this sound</string>
+    <string name="original_sound_of">Original sound - %1$s</string>
+    <string name="number_posts">%1$d posts</string>
+
 </resources>

--- a/core/src/main/java/com/puskal/core/DestinationRoute.kt
+++ b/core/src/main/java/com/puskal/core/DestinationRoute.kt
@@ -19,6 +19,7 @@ object DestinationRoute {
     const val MY_PROFILE_ROUTE = "my_profile_route"
     const val FRIENDS_ROUTE = "friends_route"
     const val CAMERA_ROUTE = "camera_route"
+    const val CHOOSE_SOUND_ROUTE = "choose_sound_route"
 
     const val AUTHENTICATION_ROUTE = "authentication_route"
     const val LOGIN_OR_SIGNUP_WITH_PHONE_EMAIL_ROUTE = "login_signup_phone_email_route"

--- a/data/src/main/java/com/puskal/data/model/AudioModel.kt
+++ b/data/src/main/java/com/puskal/data/model/AudioModel.kt
@@ -9,4 +9,8 @@ data class AudioModel(
     val audioAuthor:UserModel,
     val numberOfPost:Long,
     val originalVideoUrl:String,
-)
+){
+    fun parseCoverImage(): String =
+        if (audioCoverImage.startsWith("http")) audioCoverImage
+        else "file:///android_asset/templateimages/$audioCoverImage"
+}

--- a/data/src/main/java/com/puskal/data/repository/camermedia/AudioRepository.kt
+++ b/data/src/main/java/com/puskal/data/repository/camermedia/AudioRepository.kt
@@ -1,0 +1,12 @@
+package com.puskal.data.repository.camermedia
+
+import com.puskal.data.model.AudioModel
+import com.puskal.data.source.AudioDataSource
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class AudioRepository @Inject constructor() {
+    fun getAudios(): Flow<List<AudioModel>> {
+        return AudioDataSource.fetchAudios()
+    }
+}

--- a/data/src/main/java/com/puskal/data/source/AudioDataSource.kt
+++ b/data/src/main/java/com/puskal/data/source/AudioDataSource.kt
@@ -1,0 +1,44 @@
+package com.puskal.data.source
+
+import com.puskal.data.model.AudioModel
+import com.puskal.data.source.UsersDataSource.charliePuth
+import com.puskal.data.source.UsersDataSource.kylieJenner
+import com.puskal.data.source.UsersDataSource.duaLipa
+import com.puskal.data.source.UsersDataSource.taylor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+object AudioDataSource {
+    private val audioList = listOf(
+        AudioModel(
+            audioCoverImage = "img1.jpg",
+            isOriginal = true,
+            audioAuthor = charliePuth,
+            numberOfPost = 239000,
+            originalVideoUrl = "charlieputh_vid1.mp4"
+        ),
+        AudioModel(
+            audioCoverImage = "img2.jpg",
+            isOriginal = true,
+            audioAuthor = kylieJenner,
+            numberOfPost = 42000,
+            originalVideoUrl = "kylie_vid2.mp4"
+        ),
+        AudioModel(
+            audioCoverImage = "img3.jpg",
+            isOriginal = true,
+            audioAuthor = duaLipa,
+            numberOfPost = 120340,
+            originalVideoUrl = "dua_vid1.mp4"
+        ),
+        AudioModel(
+            audioCoverImage = "img4.jpg",
+            isOriginal = true,
+            audioAuthor = taylor,
+            numberOfPost = 15200,
+            originalVideoUrl = "taylor_vid1.mp4"
+        )
+    )
+
+    fun fetchAudios(): Flow<List<AudioModel>> = flow { emit(audioList) }
+}

--- a/domain/src/main/java/com/puskal/domain/cameramedia/GetAudioUseCase.kt
+++ b/domain/src/main/java/com/puskal/domain/cameramedia/GetAudioUseCase.kt
@@ -1,0 +1,14 @@
+package com.puskal.domain.cameramedia
+
+import com.puskal.data.model.AudioModel
+import com.puskal.data.repository.camermedia.AudioRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetAudioUseCase @Inject constructor(
+    private val audioRepository: AudioRepository
+) {
+    operator fun invoke(): Flow<List<AudioModel>> {
+        return audioRepository.getAudios()
+    }
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -12,4 +12,7 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
     composable(route = DestinationRoute.CAMERA_ROUTE) {
         CameraMediaScreen(navController)
     }
+    composable(route = DestinationRoute.CHOOSE_SOUND_ROUTE) {
+        com.puskal.cameramedia.sound.ChooseSoundScreen(navController)
+    }
 }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundContract.kt
@@ -1,0 +1,9 @@
+package com.puskal.cameramedia.sound
+
+import com.puskal.data.model.AudioModel
+
+data class ViewState(
+    val audios: List<AudioModel>? = null
+)
+
+sealed class SoundEvent

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundScreen.kt
@@ -1,0 +1,88 @@
+package com.puskal.cameramedia.sound
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import com.puskal.composable.TopBar
+import com.puskal.core.DestinationRoute
+import com.puskal.data.model.AudioModel
+import com.puskal.theme.R
+import com.puskal.theme.SubTextColor
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChooseSoundScreen(
+    navController: NavController,
+    viewModel: ChooseSoundViewModel = hiltViewModel()
+) {
+    val viewState by viewModel.viewState.collectAsState()
+
+    Scaffold(topBar = {
+        TopBar(title = stringResource(id = R.string.sounds)) {
+            navController.navigateUp()
+        }
+    }) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            viewState?.audios?.let { list ->
+                items(list) { audio ->
+                    AudioRow(audio)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AudioRow(audio: AudioModel) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            model = "file:///android_asset/templateimages/${'$'}{audio.audioCoverImage}",
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(56.dp)
+                .clip(RoundedCornerShape(6.dp))
+        )
+        Column(modifier = Modifier
+            .weight(1f)
+            .padding(start = 12.dp)) {
+            val title = if (audio.isOriginal) {
+                stringResource(id = R.string.original_sound_of, audio.audioAuthor.fullName)
+            } else audio.audioAuthor.fullName
+            Text(text = title, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                text = stringResource(id = R.string.number_posts, audio.numberOfPost),
+                style = MaterialTheme.typography.labelSmall,
+                color = SubTextColor
+            )
+        }
+        TextButton(onClick = { }) {
+            Text(text = stringResource(id = R.string.use_this_sound))
+        }
+    }
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundViewModel.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundViewModel.kt
@@ -1,0 +1,28 @@
+package com.puskal.cameramedia.sound
+
+import androidx.lifecycle.viewModelScope
+import com.puskal.core.base.BaseViewModel
+import com.puskal.domain.cameramedia.GetAudioUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ChooseSoundViewModel @Inject constructor(
+    private val getAudioUseCase: GetAudioUseCase
+) : BaseViewModel<ViewState, SoundEvent>() {
+
+    init {
+        fetchAudios()
+    }
+
+    private fun fetchAudios() {
+        viewModelScope.launch {
+            getAudioUseCase().collect { list ->
+                updateState(ViewState(audios = list))
+            }
+        }
+    }
+
+    override fun onTriggerEvent(event: SoundEvent) {}
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -48,6 +48,7 @@ import com.puskal.composable.CaptureButton
 import com.puskal.core.extension.MediumSpace
 import com.puskal.core.extension.Space
 import com.puskal.core.utils.openAppSetting
+import com.puskal.core.DestinationRoute
 import com.puskal.theme.LightGreenColor
 import com.puskal.theme.R
 import com.puskal.theme.TealColor
@@ -88,12 +89,15 @@ fun CameraScreen(
 
     Column(modifier = Modifier.fillMaxSize()) {
         if (multiplePermissionState.permissions[0].status.isGranted) {
-            CameraPreview(cameraOpenType,
+            CameraPreview(
+                cameraOpenType,
                 onClickCancel = { navController.navigateUp() },
                 onClickOpenFile = {
                     fileLauncher.launch(pickVisualMediaRequest)
+                },
+                onClickAddSound = {
+                    navController.navigate(DestinationRoute.CHOOSE_SOUND_ROUTE)
                 }
-
             )
         } else {
             CameraMicrophoneAccessPage(multiplePermissionState.permissions[1].status.isGranted,
@@ -229,6 +233,7 @@ fun CameraPreview(
     cameraOpenType: Tabs,
     onClickCancel: () -> Unit,
     onClickOpenFile: () -> Unit,
+    onClickAddSound: () -> Unit,
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -336,7 +341,9 @@ fun CameraPreview(
                     })
 
             Row(
-                modifier = Modifier.align(Alignment.TopCenter),
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .clickable { onClickAddSound() },
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {


### PR DESCRIPTION
## Summary
- add new navigation route for selecting audio
- create audio data source and repository
- implement use case and ViewModel for choose sound page
- add choose sound screen UI
- hook up Add Sound button to navigate to the new page
- provide new string resources

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbe7b1674832cb985f7d8245989e0