### PR TITLE
Add looping video editor screen

### DIFF
--- a/core/src/main/java/com/puskal/core/DestinationRoute.kt
+++ b/core/src/main/java/com/puskal/core/DestinationRoute.kt
@@ -21,6 +21,9 @@ object DestinationRoute {
     const val CAMERA_ROUTE = "camera_route"
     const val CHOOSE_SOUND_ROUTE = "choose_sound_route"
 
+    const val VIDEO_EDIT_ROUTE = "video_edit_route"
+    const val FORMATTED_VIDEO_EDIT_ROUTE = "$VIDEO_EDIT_ROUTE/{${PassedKey.VIDEO_URI}}"
+
     const val AUTHENTICATION_ROUTE = "authentication_route"
     const val LOGIN_OR_SIGNUP_WITH_PHONE_EMAIL_ROUTE = "login_signup_phone_email_route"
 
@@ -29,6 +32,7 @@ object DestinationRoute {
     object PassedKey {
         const val USER_ID = "user_id"
         const val VIDEO_INDEX = "video_index"
+        const val VIDEO_URI = "video_uri"
     }
 }
 

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -2,8 +2,13 @@ package com.puskal.cameramedia
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.puskal.core.DestinationRoute
+import com.puskal.core.DestinationRoute.FORMATTED_VIDEO_EDIT_ROUTE
+import com.puskal.core.DestinationRoute.PassedKey
+import com.puskal.cameramedia.edit.VideoEditScreen
 
 /**
  * Created by Puskal Khadka on 4/2/2023.
@@ -14,5 +19,12 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
     }
     composable(route = DestinationRoute.CHOOSE_SOUND_ROUTE) {
         com.puskal.cameramedia.sound.ChooseSoundScreen(navController)
+    }
+    composable(
+        route = FORMATTED_VIDEO_EDIT_ROUTE,
+        arguments = listOf(navArgument(PassedKey.VIDEO_URI) { type = NavType.StringType })
+    ) { backStackEntry ->
+        val uri = backStackEntry.arguments?.getString(PassedKey.VIDEO_URI) ?: ""
+        VideoEditScreen(videoUri = uri) { navController.navigateUp() }
     }
 }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -1,0 +1,56 @@
+package com.puskal.cameramedia.edit
+
+import android.net.Uri
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.media3.ui.PlayerView
+import com.puskal.composable.TopBar
+import com.puskal.theme.TikTokTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+@Composable
+fun VideoEditScreen(
+    videoUri: String,
+    onClickBack: () -> Unit
+) {
+    TikTokTheme(darkTheme = true) {
+        Scaffold(topBar = { TopBar(onClickNavIcon = onClickBack) }) { padding ->
+            val context = LocalContext.current
+            val exoPlayer = remember(videoUri) {
+                ExoPlayer.Builder(context).build().apply {
+                    repeatMode = Player.REPEAT_MODE_ONE
+                    setMediaItem(MediaItem.fromUri(Uri.parse(videoUri)))
+                    playWhenReady = true
+                    prepare()
+                }
+            }
+            DisposableEffect(exoPlayer) { onDispose { exoPlayer.release() } }
+
+            AndroidView(
+                factory = {
+                    PlayerView(it).apply {
+                        player = exoPlayer
+                        useController = false
+                        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                    }
+                },
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize()
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- include a new `VideoEditScreen` for playback of gallery videos
- add navigation route and arguments for the editor
- register the screen in cameraMedia navigation

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc54f8c20832c82cdba51389a2ab9