### PR TITLE
Fix cameramedia build by adding media3 dependency

### DIFF
--- a/feature/cameramedia/build.gradle.kts
+++ b/feature/cameramedia/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     CORE
     FEATURE_FILTER
     cameraXDependencies()
+    media3Dependency()
     implementation(project(":feature:cameracapture"))
 }


### PR DESCRIPTION
## Summary
- include Media3 libraries for cameramedia module

## Testing
- `./gradlew :feature:cameramedia:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ccc059584832cb8ab43b74ca65744