### PR TITLE
Fix deep link URI passing to video editor

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import android.net.Uri
 import com.puskal.core.DestinationRoute
 import com.puskal.core.DestinationRoute.FORMATTED_VIDEO_EDIT_ROUTE
 import com.puskal.core.DestinationRoute.PassedKey
@@ -24,7 +25,9 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
         route = FORMATTED_VIDEO_EDIT_ROUTE,
         arguments = listOf(navArgument(PassedKey.VIDEO_URI) { type = NavType.StringType })
     ) { backStackEntry ->
-        val uri = backStackEntry.arguments?.getString(PassedKey.VIDEO_URI) ?: ""
+        val uri = backStackEntry.arguments
+            ?.getString(PassedKey.VIDEO_URI)
+            ?.let { Uri.decode(it) } ?: ""
         VideoEditScreen(videoUri = uri) { navController.navigateUp() }
     }
 }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -88,7 +88,7 @@ fun CameraScreen(
             contract = ActivityResultContracts.PickMultipleVisualMedia()
         ) { uris ->
             uris.firstOrNull()?.let { uri ->
-                navController.navigate("${DestinationRoute.VIDEO_EDIT_ROUTE}/$uri")
+                navController.navigate("${DestinationRoute.VIDEO_EDIT_ROUTE}/${Uri.encode(uri.toString())}")
             }
         }
 


### PR DESCRIPTION
## Summary
- encode picked media URI when navigating to VideoEdit screen
- decode the URI in camera media navigation

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd6c7f874832cb1a8eb71230e98ad