### PR TITLE
Add icons for edit toolbar

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
@@ -1,0 +1,17 @@
+package com.puskal.cameramedia.edit
+
+import androidx.annotation.DrawableRes
+import com.puskal.theme.R
+
+enum class VideoEditTool(@DrawableRes val icon: Int) {
+    SETTINGS(R.drawable.ic_hamburger),
+    SHARE(R.drawable.ic_share),
+    TRIM(R.drawable.ic_delete),
+    TEXT(R.drawable.ic_mention),
+    CHALLENGE(R.drawable.ic_flag),
+    STICKERS(R.drawable.ic_emoji),
+    EFFECTS(R.drawable.ic_wallpaper),
+    FILTERS(R.drawable.ic_filter),
+    BEAUTY(R.drawable.ic_profile_fill),
+    CROP_RESIZE(R.drawable.ic_arrow_down)
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -1,8 +1,10 @@
 package com.puskal.cameramedia.edit
 
 import android.net.Uri
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Alignment
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -18,6 +20,10 @@ import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import com.puskal.composable.TopBar
 import com.puskal.theme.TikTokTheme
+import androidx.compose.ui.unit.dp
+
+import com.puskal.cameramedia.edit.VideoEditToolBar
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
@@ -39,18 +45,28 @@ fun VideoEditScreen(
             }
             DisposableEffect(exoPlayer) { onDispose { exoPlayer.release() } }
 
-            AndroidView(
-                factory = {
-                    PlayerView(it).apply {
-                        player = exoPlayer
-                        useController = false
-                        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
-                    }
-                },
+            Box(
                 modifier = Modifier
                     .padding(padding)
                     .fillMaxSize()
-            )
+            ) {
+                AndroidView(
+                    factory = {
+                        PlayerView(it).apply {
+                            player = exoPlayer
+                            useController = false
+                            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                        }
+                    },
+                    modifier = Modifier.fillMaxSize()
+                )
+
+                VideoEditToolBar(
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(end = 16.dp)
+                )
+            }
         }
     }
 }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
@@ -1,0 +1,35 @@
+package com.puskal.cameramedia.edit
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.Image
+
+@Composable
+fun VideoEditToolBar(
+    modifier: Modifier = Modifier,
+    onToolSelected: (VideoEditTool) -> Unit = {}
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        VideoEditTool.values().forEach { tool ->
+            Image(
+                painter = painterResource(id = tool.icon),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(32.dp)
+                    .clickable { onToolSelected(tool) },
+                alignment = Alignment.Center
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `VideoEditTool` enum for edit actions
- build `VideoEditToolBar` composable with icon-only tools
- overlay toolbar on `VideoEditScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce085b9c0832c8f0acf81840e8ef5