### PR TITLE
Add basic resize toolbar menus

### DIFF
--- a/common/theme/src/main/res/drawable/ic_auto_subtitles.xml
+++ b/common/theme/src/main/res/drawable/ic_auto_subtitles.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M2,4H22V6H2z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M2,9H22V11H2z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M2,14H14V16H2z"/>
+</vector>

--- a/common/theme/src/main/res/drawable/ic_brush_tool.xml
+++ b/common/theme/src/main/res/drawable/ic_brush_tool.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M7,17L2,22H7V17zM8.5,16.5L19,6L18,5L7.5,15.5L8.5,16.5zM20,4L19,3L17,5L18,6L20,4z"/>
+</vector>

--- a/common/theme/src/main/res/drawable/ic_quality_enhance.xml
+++ b/common/theme/src/main/res/drawable/ic_quality_enhance.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.63L12,2L9.19,8.63L2,9.24L7.46,13.97L5.82,21L12,17.27Z"/>
+</vector>

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/ResizeToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/ResizeToolBar.kt
@@ -1,0 +1,35 @@
+package com.puskal.cameramedia.edit
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ResizeToolBar(
+    modifier: Modifier = Modifier,
+    onFeatureSelected: (ResizeMenuFeature) -> Unit = {}
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        ResizeMenuFeature.values().forEach { feature ->
+            Image(
+                painter = painterResource(id = feature.icon),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(32.dp)
+                    .clickable { onFeatureSelected(feature) },
+                alignment = Alignment.Center
+            )
+        }
+    }
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
@@ -15,3 +15,11 @@ enum class VideoEditTool(@DrawableRes val icon: Int) {
     BEAUTY(R.drawable.ic_profile_fill),
     CROP_RESIZE(R.drawable.ic_arrow_down)
 }
+
+enum class ResizeMenuFeature(@DrawableRes val icon: Int) {
+    AUTO_SUBTITLES(R.drawable.ic_auto_subtitles),
+    QUALITY_ENHANCEMENT(R.drawable.ic_quality_enhance),
+    VOICE_CHANGER(R.drawable.ic_microphone),
+    BRUSH_TOOL(R.drawable.ic_brush_tool),
+    COLLAPSE_TOOLBAR(R.drawable.ic_arrow_down)
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -10,6 +10,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
@@ -23,6 +26,8 @@ import com.puskal.theme.TikTokTheme
 import androidx.compose.ui.unit.dp
 
 import com.puskal.cameramedia.edit.VideoEditToolBar
+import com.puskal.cameramedia.edit.VideoEditTool
+import com.puskal.cameramedia.edit.ResizeToolBar
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -35,6 +40,7 @@ fun VideoEditScreen(
     TikTokTheme(darkTheme = true) {
         Scaffold(topBar = { TopBar(onClickNavIcon = onClickBack) }) { padding ->
             val context = LocalContext.current
+            var showResizeMenu by remember { mutableStateOf(false) }
             val exoPlayer = remember(videoUri) {
                 ExoPlayer.Builder(context).build().apply {
                     repeatMode = Player.REPEAT_MODE_ONE
@@ -61,10 +67,23 @@ fun VideoEditScreen(
                     modifier = Modifier.fillMaxSize()
                 )
 
+                if (showResizeMenu) {
+                    ResizeToolBar(
+                        modifier = Modifier
+                            .align(Alignment.CenterEnd)
+                            .padding(end = 64.dp)
+                    )
+                }
+
                 VideoEditToolBar(
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
-                        .padding(end = 16.dp)
+                        .padding(end = 16.dp),
+                    onToolSelected = {
+                        if (it == VideoEditTool.CROP_RESIZE) {
+                            showResizeMenu = !showResizeMenu
+                        }
+                    }
                 )
             }
         }


### PR DESCRIPTION
## Summary
- add icons for new editing tools
- define `ResizeMenuFeature` enum
- implement `ResizeToolBar` composable
- show the resize toolbar in `VideoEditScreen`

## Testing
- `./gradlew tasks --all | head -n 20`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce4b7c820832c87ba0ffa34e4e5b0