### PR TITLE
Use Material icons in video editor toolbar

### DIFF
--- a/buildSrc/src/main/java/DependencyHandler.kt
+++ b/buildSrc/src/main/java/DependencyHandler.kt
@@ -25,6 +25,7 @@ fun DependencyHandler.composeDependencies() {
     implementation(Libraries.Compose.composeFoundation)
     implementation(Libraries.Compose.composeRuntime)
     implementation(Libraries.Compose.composeMaterial3)
+    implementation(Libraries.Compose.materialIconsExtended)
 
     //navgation
     implementation(Libraries.Naviagtion.navigationCompose)

--- a/buildSrc/src/main/java/Libraries.kt
+++ b/buildSrc/src/main/java/Libraries.kt
@@ -41,6 +41,7 @@ object Version {
     const val CameraXVersion = "1.3.0-alpha05"
     const val GuavaAndroid="31.0.1-android"
     const val Material = "1.11.0"
+    const val MaterialIconsExtended = "1.8.3"
 }
 
 
@@ -64,6 +65,8 @@ object Libraries {
         const val composeUiUtil = "androidx.compose.ui:ui-util"
         const val constraintLayoutCompose =
             "androidx.constraintlayout:constraintlayout-compose:$ConstraintLayoutCompose"
+        const val materialIconsExtended =
+            "androidx.compose.material:material-icons-extended:${Version.MaterialIconsExtended}"
     }
 
     object Google {

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
@@ -3,10 +3,10 @@ package com.puskal.cameramedia.edit
 import androidx.annotation.DrawableRes
 import com.puskal.theme.R
 
-enum class VideoEditTool(@DrawableRes val icon: Int) {
-    SETTINGS(R.drawable.ic_hamburger),
-    SHARE(R.drawable.ic_share),
-    TRIM(R.drawable.ic_delete),
+enum class VideoEditTool(@DrawableRes val iconRes: Int? = null) {
+    SETTINGS(),
+    SHARE(),
+    TRIM(),
     TEXT(R.drawable.ic_mention),
     CHALLENGE(R.drawable.ic_flag),
     STICKERS(R.drawable.ic_emoji),

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
@@ -9,7 +9,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.Image
+import androidx.compose.material3.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCut
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Share
 
 @Composable
 fun VideoEditToolBar(
@@ -22,14 +26,31 @@ fun VideoEditToolBar(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         VideoEditTool.values().forEach { tool ->
-            Image(
-                painter = painterResource(id = tool.icon),
-                contentDescription = null,
-                modifier = Modifier
-                    .size(32.dp)
-                    .clickable { onToolSelected(tool) },
-                alignment = Alignment.Center
-            )
+            val iconModifier = Modifier
+                .size(32.dp)
+                .clickable { onToolSelected(tool) }
+            when (tool) {
+                VideoEditTool.SETTINGS -> Icon(
+                    imageVector = Icons.Filled.Settings,
+                    contentDescription = null,
+                    modifier = iconModifier
+                )
+                VideoEditTool.SHARE -> Icon(
+                    imageVector = Icons.Filled.Share,
+                    contentDescription = null,
+                    modifier = iconModifier
+                )
+                VideoEditTool.TRIM -> Icon(
+                    imageVector = Icons.Filled.ContentCut,
+                    contentDescription = null,
+                    modifier = iconModifier
+                )
+                else -> Icon(
+                    painter = painterResource(id = tool.iconRes!!),
+                    contentDescription = null,
+                    modifier = iconModifier
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add material-icons-extended v1.8.3 dependency
- integrate the icons into compose dependencies
- switch `VideoEditTool` to support built-in icons
- display built-in icons in `VideoEditToolBar`

## Testing
- `gradlew --version`
- `gradlew :buildSrc:jar` *(fails: Android plugin class not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce64a3890832c957e86cf1b6f8135