### PR TITLE
Switch toolbar to Material icons

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
@@ -1,19 +1,31 @@
 package com.puskal.cameramedia.edit
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCut
+import androidx.compose.material.icons.filled.Crop
+import androidx.compose.material.icons.filled.EmojiEmotions
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Filter
+import androidx.compose.material.icons.filled.Flag
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.TextFields
+import androidx.compose.material.icons.filled.Wallpaper
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.annotation.DrawableRes
 import com.puskal.theme.R
 
-enum class VideoEditTool(@DrawableRes val iconRes: Int? = null) {
-    SETTINGS(),
-    SHARE(),
-    TRIM(),
-    TEXT(R.drawable.ic_mention),
-    CHALLENGE(R.drawable.ic_flag),
-    STICKERS(R.drawable.ic_emoji),
-    EFFECTS(R.drawable.ic_wallpaper),
-    FILTERS(R.drawable.ic_filter),
-    BEAUTY(R.drawable.ic_profile_fill),
-    CROP_RESIZE(R.drawable.ic_arrow_down)
+enum class VideoEditTool(val icon: ImageVector) {
+    SETTINGS(Icons.Filled.Settings),
+    SHARE(Icons.Filled.Share),
+    TRIM(Icons.Filled.ContentCut),
+    TEXT(Icons.Filled.TextFields),
+    CHALLENGE(Icons.Filled.Flag),
+    STICKERS(Icons.Filled.EmojiEmotions),
+    EFFECTS(Icons.Filled.Wallpaper),
+    FILTERS(Icons.Filled.Filter),
+    BEAUTY(Icons.Filled.Face),
+    CROP_RESIZE(Icons.Filled.Crop)
 }
 
 enum class ResizeMenuFeature(@DrawableRes val icon: Int) {

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
@@ -7,13 +7,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.Icon
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ContentCut
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Share
 
 @Composable
 fun VideoEditToolBar(
@@ -26,31 +21,13 @@ fun VideoEditToolBar(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         VideoEditTool.values().forEach { tool ->
-            val iconModifier = Modifier
-                .size(32.dp)
-                .clickable { onToolSelected(tool) }
-            when (tool) {
-                VideoEditTool.SETTINGS -> Icon(
-                    imageVector = Icons.Filled.Settings,
-                    contentDescription = null,
-                    modifier = iconModifier
-                )
-                VideoEditTool.SHARE -> Icon(
-                    imageVector = Icons.Filled.Share,
-                    contentDescription = null,
-                    modifier = iconModifier
-                )
-                VideoEditTool.TRIM -> Icon(
-                    imageVector = Icons.Filled.ContentCut,
-                    contentDescription = null,
-                    modifier = iconModifier
-                )
-                else -> Icon(
-                    painter = painterResource(id = tool.iconRes!!),
-                    contentDescription = null,
-                    modifier = iconModifier
-                )
-            }
+            Icon(
+                imageVector = tool.icon,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(32.dp)
+                    .clickable { onToolSelected(tool) }
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- update `VideoEditTool` to provide `ImageVector` icons from the Material library
- simplify `VideoEditToolBar` to use the icon property directly

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce92fb24c832cae4b09de2c41c6c8