### PR TITLE
Fix compose icons artifact

### DIFF
--- a/buildSrc/src/main/java/Libraries.kt
+++ b/buildSrc/src/main/java/Libraries.kt
@@ -41,7 +41,6 @@ object Version {
     const val CameraXVersion = "1.3.0-alpha05"
     const val GuavaAndroid="31.0.1-android"
     const val Material = "1.11.0"
-    const val MaterialIconsExtended = "1.8.3"
 }
 
 
@@ -66,7 +65,7 @@ object Libraries {
         const val constraintLayoutCompose =
             "androidx.constraintlayout:constraintlayout-compose:$ConstraintLayoutCompose"
         const val materialIconsExtended =
-            "androidx.compose.material:material-icons-extended:${Version.MaterialIconsExtended}"
+            "androidx.compose.material:material-icons-extended"
     }
 
     object Google {


### PR DESCRIPTION
## Summary
- remove missing material icons version and rely on Compose BOM

## Testing
- `./gradlew help --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_687ce991d1b8832c846479e624406753