### PR TITLE
Add shared MusicBarLayout to video edit screen

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/MusicBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/MusicBar.kt
@@ -1,0 +1,42 @@
+package com.puskal.cameramedia
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.puskal.theme.R
+
+/**
+ * Simple bar showing an icon and text for adding music.
+ */
+@Composable
+fun MusicBarLayout(
+    modifier: Modifier = Modifier,
+    onClickAddSound: () -> Unit
+) {
+    Row(
+        modifier = modifier.clickable { onClickAddSound() },
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_music_note),
+            contentDescription = null,
+            modifier = Modifier.size(18.dp)
+        )
+        Text(
+            text = stringResource(id = R.string.add_sound),
+            style = MaterialTheme.typography.labelLarge
+        )
+    }
+}
+

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -23,6 +23,7 @@ import androidx.media3.ui.PlayerView
 import com.puskal.composable.TopBar
 import com.puskal.theme.TikTokTheme
 import androidx.compose.ui.unit.dp
+import com.puskal.cameramedia.MusicBarLayout
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 @Composable
@@ -58,6 +59,11 @@ fun VideoEditScreen(
                         }
                     },
                     modifier = Modifier.fillMaxSize()
+                )
+
+                MusicBarLayout(
+                    modifier = Modifier.align(Alignment.TopCenter),
+                    onClickAddSound = {}
                 )
 
                 if (showResizeMenu) {

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -346,23 +346,10 @@ fun CameraPreview(
                         onClickCancel()
                     })
 
-            Row(
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .clickable { onClickAddSound() },
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    painterResource(id = R.drawable.ic_music_note),
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                )
-                Text(
-                    text = stringResource(id = R.string.add_sound),
-                    style = MaterialTheme.typography.labelLarge
-                )
-            }
+            MusicBarLayout(
+                modifier = Modifier.align(Alignment.TopCenter),
+                onClickAddSound = onClickAddSound
+            )
             if (showFilterSheet) {
                 FilterBottomSheet(
                     currentFilter = selectedFilter,


### PR DESCRIPTION
## Summary
- extract Add Sound row from CameraScreen into a reusable `MusicBarLayout`
- reuse the new layout in `CameraScreen` and `VideoEditScreen`

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf0c1d3d0832c943c76e00858552d