### PR TITLE
Fix add sound position in VideoEditScreen

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -77,7 +77,9 @@ fun VideoEditScreen(
                 )
 
                 MusicBarLayout(
-                    modifier = Modifier.align(Alignment.TopCenter),
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(top = 32.dp),
                     onClickAddSound = {}
                 )
 


### PR DESCRIPTION
## Summary
- add top padding to MusicBar in video editor so it matches CameraScreen

## Testing
- `./gradlew test --no-daemon` *(fails: missing JDK / aborted)*

------
https://chatgpt.com/codex/tasks/task_e_687cf525be94832c89e3b448e9ad5315