### PR TITLE
Fix video not showing in trim screen

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
@@ -73,6 +73,8 @@ fun VideoTrimScreen(
                     PlayerView(it).apply {
                         player = exoPlayer
                         useController = false
+                        // Use a TextureView so the video layers correctly with other Compose UI
+                        useTextureView = true
                         resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
                     }
                 },


### PR DESCRIPTION
## Summary
- use `useTextureView` in `VideoTrimScreen` player initialization so the video output layers correctly with Compose UI

## Testing
- `./gradlew test --no-daemon` *(fails: could not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687d00e27df4832c90e063e4db55b2d4