### PR TITLE
Add timeline UI to VideoTrimScreen

### DIFF
--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -106,6 +106,8 @@
     <string name="demo_video_compositor">This is a demo for video compositor</string>
 
     <string name="trim">Trim</string>
+    <string name="cancel">Cancel</string>
+    <string name="save">Save</string>
 
     <!-- choose sound -->
     <string name="sounds">Sounds</string>

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -48,6 +48,10 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
         val uri = backStackEntry.arguments
             ?.getString(PassedKey.VIDEO_URI)
             ?.let { Uri.decode(it) } ?: ""
-        VideoTrimScreen(videoUri = uri) { navController.navigateUp() }
+        VideoTrimScreen(
+            videoUri = uri,
+            onCancel = { navController.navigateUp() },
+            onSave = { navController.navigateUp() }
+        )
     }
 }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/TimelineEditor.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/TimelineEditor.kt
@@ -1,0 +1,79 @@
+package com.puskal.cameramedia.edit
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.ZoomIn
+import androidx.compose.material.icons.filled.ZoomOut
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TimelineEditor(modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            IconButton(onClick = { }) {
+                Icon(
+                    imageVector = Icons.Filled.ZoomOut,
+                    contentDescription = null,
+                    tint = Color.White
+                )
+            }
+            IconButton(onClick = { }) {
+                Icon(
+                    imageVector = Icons.Filled.ZoomIn,
+                    contentDescription = null,
+                    tint = Color.White
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(64.dp)
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            repeat(10) {
+                Box(
+                    modifier = Modifier
+                        .size(width = 60.dp, height = 64.dp)
+                        .background(
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
+                        )
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(24.dp)
+                .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
+        ) {
+            Icon(
+                imageVector = Icons.Filled.MusicNote,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = 8.dp)
+            )
+        }
+    }
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
@@ -1,8 +1,7 @@
 package com.puskal.cameramedia.edit
 
 import android.net.Uri
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.clickable
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -10,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.runtime.*
@@ -24,15 +24,20 @@ import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import com.puskal.theme.TikTokTheme
 import com.puskal.theme.R
+import com.puskal.cameramedia.edit.TimelineEditor
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VideoTrimScreen(
     videoUri: String,
-    onBack: () -> Unit = {}
+    onCancel: () -> Unit = {},
+    onSave: () -> Unit = {}
 ) {
     TikTokTheme(darkTheme = true) {
         var selectedTool by remember { mutableStateOf(TrimTool.TRIM) }
@@ -41,14 +46,22 @@ fun VideoTrimScreen(
                 CenterAlignedTopAppBar(
                     title = { Text(text = stringResource(id = R.string.trim)) },
                     navigationIcon = {
-                        Icon(
-                            painter = androidx.compose.ui.res.painterResource(id = R.drawable.ic_arrow_back),
-                            contentDescription = null,
-                            tint = Color.Unspecified,
-                            modifier = Modifier
-                                .padding(start = 8.dp)
-                                .clickable { onBack() }
-                        )
+                        IconButton(onClick = onCancel) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = stringResource(id = R.string.cancel),
+                                tint = Color.Unspecified
+                            )
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = onSave) {
+                            Icon(
+                                imageVector = Icons.Filled.Check,
+                                contentDescription = stringResource(id = R.string.save),
+                                tint = Color.Unspecified
+                            )
+                        }
                     },
                     colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color.Transparent)
                 )
@@ -68,18 +81,40 @@ fun VideoTrimScreen(
             }
             DisposableEffect(exoPlayer) { onDispose { exoPlayer.release() } }
 
-            AndroidView(
-                factory = {
-                    PlayerView(it).apply {
-                        player = exoPlayer
-                        useController = false
-                        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
-                    }
-                },
+            var isPlaying by remember { mutableStateOf(true) }
+            LaunchedEffect(isPlaying) {
+                if (isPlaying) exoPlayer.play() else exoPlayer.pause()
+            }
+
+            Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)
-            )
+            ) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .clickable { isPlaying = !isPlaying }
+                ) {
+                    AndroidView(
+                        factory = {
+                            PlayerView(it).apply {
+                                player = exoPlayer
+                                useController = false
+                                resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                            }
+                        },
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+
+                TimelineEditor(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Cancel/Save strings
- create `TimelineEditor` composable
- show cancel/save buttons on `VideoTrimScreen`
- include timeline editor and play/pause toggle
- update navigation to use new parameters

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cfee089f0832c8ad23661bfb52926