### PR TITLE
Fix VideoTrimScreen syntax error and playback control

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
@@ -81,7 +81,13 @@ fun VideoTrimScreen(
             }
             DisposableEffect(exoPlayer) { onDispose { exoPlayer.release() } }
 
-            modifier = Modifier
+            var isPlaying by remember { mutableStateOf(true) }
+            LaunchedEffect(isPlaying) {
+                if (isPlaying) exoPlayer.play() else exoPlayer.pause()
+            }
+
+            Column(
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)
             ) {


### PR DESCRIPTION
## Summary
- fix invalid structure in `VideoTrimScreen` by wrapping controls in a `Column`
- add state handling to play/pause video

## Testing
- `./gradlew :feature:cameramedia:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d0549fe24832c8e46f3a417869bad