### PR TITLE
Fix composable API usage

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaContract.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Filter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.runtime.Composable
 import com.puskal.data.model.TemplateModel
 import com.puskal.theme.R
 
@@ -33,15 +34,23 @@ enum class PermissionType {
 
 enum class CameraController(
     @StringRes val title: Int,
-    val icon: ImageVector
+    val iconRes: Int? = null,
+    val iconVector: ImageVector? = null,
 ) {
-    FLIP(title = R.string.flip, icon = ImageVector.vectorResource(R.drawable.ic_flip)),
-    SPEED(title = R.string.speed, icon = ImageVector.vectorResource(R.drawable.ic_speed)),
-    BEAUTY(title = R.string.beauty, icon = ImageVector.vectorResource(R.drawable.ic_profile_fill)),
-    FILTER(title = R.string.filters, icon = Icons.Filled.Filter),
-    MIRROR(title = R.string.mirror, icon = ImageVector.vectorResource(R.drawable.ic_mirror)),
-    TIMER(title = R.string.timer, icon = ImageVector.vectorResource(R.drawable.ic_timer)),
-    FLASH(title = R.string.flash, icon = ImageVector.vectorResource(R.drawable.ic_flash)),
+    FLIP(title = R.string.flip, iconRes = R.drawable.ic_flip),
+    SPEED(title = R.string.speed, iconRes = R.drawable.ic_speed),
+    BEAUTY(title = R.string.beauty, iconRes = R.drawable.ic_profile_fill),
+    FILTER(title = R.string.filters, iconVector = Icons.Filled.Filter),
+    MIRROR(title = R.string.mirror, iconRes = R.drawable.ic_mirror),
+    TIMER(title = R.string.timer, iconRes = R.drawable.ic_timer),
+    FLASH(title = R.string.flash, iconRes = R.drawable.ic_flash),
+}
+
+@Composable
+fun CameraController.icon(): ImageVector {
+    iconVector?.let { return it }
+    val resId = iconRes ?: error("No icon defined for $this")
+    return ImageVector.vectorResource(resId)
 }
 
 enum class CameraCaptureOptions(val value: String) {

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
@@ -103,7 +103,7 @@ fun VideoTrimScreen(
                                 player = exoPlayer
                                 useController = false
                                 // Use a TextureView so the video layers correctly with other Compose UI
-                                useTextureView = true
+                                setUseTextureView(true)
                                 resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
                             }
                         },

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -534,7 +534,7 @@ fun ControllerItem(
         onClickController(cameraController)
     }) {
         Icon(
-            imageVector = cameraController.icon,
+            imageVector = cameraController.icon(),
             contentDescription = null,
             modifier = Modifier.size(27.dp),
             tint = Color.White.copy(alpha = 0.8f)


### PR DESCRIPTION
## Summary
- avoid calling ImageVector.vectorResource outside of composables
- fix PlayerView setup in trimming screen

## Testing
- `./gradlew tasks --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687d091dac74832c8058f100c3f3d984