### PR TITLE
Replace RangeSlider with RangeSeekBarView

### DIFF
--- a/common/videotrimmer/src/main/res/layout/trimmer_view_layout.xml
+++ b/common/videotrimmer/src/main/res/layout/trimmer_view_layout.xml
@@ -4,10 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <com.google.android.material.slider.RangeSlider
+    <com.puskal.videotrimmer.RangeSeekBarView
         android:id="@+id/rangeSlider"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        app:values="0,100" />
+        android:layout_margin="16dp" />
 </FrameLayout>


### PR DESCRIPTION
## Summary
- use the custom `RangeSeekBarView` in video trimmer layout so default values are set

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d1c12a49c832cbd69ff1862ad3870