### PR TITLE
Fix video trimmer build

### DIFF
--- a/feature/video-trimmer/build.gradle.kts
+++ b/feature/video-trimmer/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     implementation(Libraries.AndroidX.coreKtx)
     implementation(Libraries.AndroidX.appCompat)
     implementation(Libraries.Google.material)
+    media3Dependency()
+    implementation("com.github.CanHub:Android-Image-Cropper:4.3.2")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation(Libraries.Test.junitExtKtx)
     androidTestImplementation(Libraries.Test.espressorCore)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://jitpack.io")
     }
 }
 rootProject.name = "tiktokcompose"


### PR DESCRIPTION
## Summary
- add required Media3 and Cropper libraries for the video-trimmer feature
- add JitPack repository for cropper library

## Testing
- `./gradlew :feature:video-trimmer:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e34b972f0832ca6abdff23fec3b27