### PR TITLE
Fix build config for video-trimmer module

### DIFF
--- a/feature/video-trimmer/build.gradle.kts
+++ b/feature/video-trimmer/build.gradle.kts
@@ -1,53 +1,8 @@
-import AppConfig
-import Libraries
-
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-}
-
-android {
-    namespace = "com.redevrx.video_trimmer"
-    compileSdk = AppConfig.compileSdk
-
-    defaultConfig {
-        applicationId = "com.redevrx.video_trimmer"
-        minSdk = AppConfig.minSdk
-        targetSdk = AppConfig.targetSdk
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
+    id("plugin.android-common")
 }
 
 dependencies {
-
-    implementation(Libraries.AndroidX.coreKtx)
-    implementation(Libraries.AndroidX.appCompat)
-    implementation(Libraries.Google.material)
     media3Dependency()
     implementation("com.github.CanHub:Android-Image-Cropper:4.3.2")
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation(Libraries.Test.junitExtKtx)
-    androidTestImplementation(Libraries.Test.espressorCore)
-    androidTestImplementation(Libraries.Test.testCoreKtx)
-    androidTestImplementation(Libraries.Test.runner)
 }

--- a/feature/video-trimmer/src/main/AndroidManifest.xml
+++ b/feature/video-trimmer/src/main/AndroidManifest.xml
@@ -1,12 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/Theme.Tiktokcompose" />
-
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
## Summary
- convert `feature/video-trimmer` into a library module
- clean up its manifest

## Testing
- `./gradlew :feature:video-trimmer:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e36f2d8f4832ca399d99e505bd8d0