### PR TITLE
Update Media3 version for transformer API

### DIFF
--- a/buildSrc/src/main/java/Libraries.kt
+++ b/buildSrc/src/main/java/Libraries.kt
@@ -33,7 +33,7 @@ object Version {
     const val Coil = "2.2.2"
     const val HiltNavigationCompose = "1.0.0"
     const val HiltAndroidVersion = "2.44"
-    const val Media3 = "1.0.0-rc02"
+    const val Media3 = "1.3.1"
     const val Accompanist = "0.36.0"
     const val SplashScreenApi = "1.0.1"
     const val ConstraintLayoutCompose = "1.0.1"


### PR DESCRIPTION
## Summary
- bump Media3 to 1.3.1 so the video editor builds against the transformer API

## Testing
- `./gradlew :feature:video-trimmer:assembleDebug --no-daemon` *(fails: Path for java installation '/usr/lib/jvm/openjdk-21' does not contain a java executable)*

------
https://chatgpt.com/codex/tasks/task_e_687e3a4a401c832ca7c237108fda12ae