### PR TITLE
Fix VideoEditor constructor for direct usage

### DIFF
--- a/feature/video-trimmer/src/main/java/com/redevrx/video_trimmer/view/VideoEditor.kt
+++ b/feature/video-trimmer/src/main/java/com/redevrx/video_trimmer/view/VideoEditor.kt
@@ -51,7 +51,7 @@ import javax.xml.transform.Transformer
 
 class VideoEditor @JvmOverloads constructor(
     context: Context,
-    attrs: AttributeSet,
+    attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr) {
 


### PR DESCRIPTION
## Summary
- allow VideoEditor to be instantiated without an `AttributeSet`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3f76c494832ca0d2e824baf3e2d8