### PR TITLE
Update cropper lib and cleanup jitpack

### DIFF
--- a/feature/video-trimmer/build.gradle.kts
+++ b/feature/video-trimmer/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation(Libraries.AndroidX.appCompat)
     implementation(Libraries.Google.material)
     media3Dependency()
-    implementation("com.github.CanHub:Android-Image-Cropper:4.5.0")
+    implementation("com.vanniktech:android-image-cropper:4.6.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation(Libraries.Test.junitExtKtx)
     androidTestImplementation(Libraries.Test.espressorCore)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://jitpack.io")
     }
 }
 rootProject.name = "tiktokcompose"


### PR DESCRIPTION
## Summary
- update the image cropper dependency
- remove jitpack repository

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e41af1f24832c9d612c0ec9483a24