### PR TITLE
Fix comment ViewModel retrieval

### DIFF
--- a/feature/commentlisting/src/main/java/com/puskal/commentlisting/CommentListScreen.kt
+++ b/feature/commentlisting/src/main/java/com/puskal/commentlisting/CommentListScreen.kt
@@ -24,11 +24,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
-import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.puskal.core.extension.Space
 import com.puskal.data.model.CommentList
+import com.puskal.commentlisting.CommentListViewModel
 import com.puskal.theme.DarkBlue
 import com.puskal.theme.GrayMainColor
 import com.puskal.theme.R
@@ -42,7 +42,7 @@ import com.puskal.theme.SubTextColor
 
 @Composable
 fun CommentListScreen(
-    viewModel: CommentListViewModel = hiltViewModel(),
+    viewModel: CommentListViewModel,
     onClickCancel: () -> Unit
 ) {
     val viewState by viewModel.viewState.collectAsState()

--- a/feature/commentlisting/src/main/java/com/puskal/commentlisting/CommentListingNavigation.kt
+++ b/feature/commentlisting/src/main/java/com/puskal/commentlisting/CommentListingNavigation.kt
@@ -2,9 +2,11 @@ package com.puskal.commentlisting
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.google.accompanist.navigation.material.bottomSheet
 import com.puskal.core.DestinationRoute.COMMENT_BOTTOM_SHEET_ROUTE
+import com.puskal.commentlisting.CommentListViewModel
 
 /**
  * Created by Puskal Khadka on 3/22/2023.
@@ -12,7 +14,11 @@ import com.puskal.core.DestinationRoute.COMMENT_BOTTOM_SHEET_ROUTE
 
 @OptIn(ExperimentalMaterialNavigationApi::class)
 fun NavGraphBuilder.commentListingNavGraph(navController: NavController) {
-    bottomSheet(route = COMMENT_BOTTOM_SHEET_ROUTE) {
-        CommentListScreen(onClickCancel = { navController.navigateUp() })
+    bottomSheet(route = COMMENT_BOTTOM_SHEET_ROUTE) { backStackEntry ->
+        val viewModel: CommentListViewModel = hiltViewModel(backStackEntry)
+        CommentListScreen(
+            viewModel = viewModel,
+            onClickCancel = { navController.navigateUp() }
+        )
     }
 }


### PR DESCRIPTION
## Summary
- retrieve `CommentListViewModel` in the `bottomSheet` lambda in `CommentListingNavigation`
- require `CommentListViewModel` parameter for `CommentListScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4537e968832cbfb51983dba47ec5