### PR TITLE
Add gesture mappings to CameraView

### DIFF
--- a/docs/CameraRecording.md
+++ b/docs/CameraRecording.md
@@ -93,6 +93,9 @@ val cameraView = remember {
         setLifecycleOwner(lifecycleOwner)
         mode = Mode.PICTURE
         facing = defaultCameraFacing
+        mapGesture(Gesture.PINCH, GestureAction.ZOOM)
+        mapGesture(Gesture.TAP, GestureAction.AUTO_FOCUS)
+        mapGesture(Gesture.LONG_TAP, GestureAction.TAKE_PICTURE)
     }
 }
 ```

--- a/docs/camera_photo_capture_player.md
+++ b/docs/camera_photo_capture_player.md
@@ -30,6 +30,9 @@ val cameraView = remember {
         setLifecycleOwner(lifecycleOwner)
         mode = Mode.PICTURE
         facing = defaultCameraFacing
+        mapGesture(Gesture.PINCH, GestureAction.ZOOM)
+        mapGesture(Gesture.TAP, GestureAction.AUTO_FOCUS)
+        mapGesture(Gesture.LONG_TAP, GestureAction.TAKE_PICTURE)
     }
 }
 ...

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -10,6 +10,8 @@ import com.otaliastudios.cameraview.PictureResult
 import com.otaliastudios.cameraview.VideoResult
 import com.otaliastudios.cameraview.controls.Mode
 import com.otaliastudios.cameraview.controls.Facing
+import com.otaliastudios.cameraview.gesture.Gesture
+import com.otaliastudios.cameraview.gesture.GestureAction
 import java.io.File
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -254,6 +256,9 @@ fun CameraPreview(
             setLifecycleOwner(lifecycleOwner)
             mode = Mode.PICTURE
             facing = defaultCameraFacing
+            mapGesture(Gesture.PINCH, GestureAction.ZOOM)
+            mapGesture(Gesture.TAP, GestureAction.AUTO_FOCUS)
+            mapGesture(Gesture.LONG_TAP, GestureAction.TAKE_PICTURE)
         }
     }
     LaunchedEffect(selectedFilter) {


### PR DESCRIPTION
## Summary
- enable pinch-to-zoom, tap-to-focus, and long-tap capture for the camera
- document gesture mapping in camera docs

## Testing
- `./gradlew test` *(fails: Path for java installation '/usr/lib/jvm/openjdk-21' does not contain a java executable)*

------
https://chatgpt.com/codex/tasks/task_e_687e4a28b018832c80e80cbb47881c3a