### PR TITLE
Add mp4compose dependency to camera module

### DIFF
--- a/feature/cameramedia/build.gradle.kts
+++ b/feature/cameramedia/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     DATA
     CORE
     FEATURE_FILTER
+    implementation(project(":feature:mp4compose"))
     cameraXDependencies()
     media3Dependency()
     implementation(project(":feature:video-trimmer"))


### PR DESCRIPTION
## Summary
- wire up the local `mp4compose` module for the `cameramedia` feature

## Testing
- `./gradlew test` *(fails: Path for java installation `/usr/lib/jvm/openjdk-21` does not contain a java executable)*

------
https://chatgpt.com/codex/tasks/task_e_687e4d369ce4832ca74ffc23a473f14c