### PR TITLE
Fix mp4compose build configuration

### DIFF
--- a/feature/mp4compose/build.gradle
+++ b/feature/mp4compose/build.gradle
@@ -2,14 +2,13 @@ apply plugin: 'com.android.library'
 
 android {
   namespace 'com.daasuu.mp4compose'
-  compileSdkVersion COMPILE_SDK_VERSION as int
-  buildToolsVersion BUILD_TOOLS_VERSION
+  compileSdkVersion 35
 
   defaultConfig {
-    minSdkVersion COMPILE_MIN_SDK_VERSION as int
-    targetSdkVersion COMPILE_SDK_VERSION as int
-    versionCode VERSION_CODE as int
-    versionName VERSION_NAME
+    minSdkVersion 21
+    targetSdkVersion 35
+    versionCode 1
+    versionName "1.0.0"
   }
 
   buildTypes {


### PR DESCRIPTION
## Summary
- update `mp4compose` build.gradle to use numeric SDK values

## Testing
- `./gradlew tasks --all` *(fails: Path for java installation '/usr/lib/jvm/openjdk-21' does not contain a java executable)*

------
https://chatgpt.com/codex/tasks/task_e_687e515c580c832cba51c265a49ea772