### PR TITLE
Release VideoEditor when leaving trim screen

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
@@ -41,6 +41,13 @@ fun VideoTrimScreen(
         var isSaving by remember { mutableStateOf(false) }
         val editorRef = remember { mutableStateOf<VideoEditor?>(null) }
 
+        DisposableEffect(Unit) {
+            onDispose {
+                editorRef.value?.onPause()
+                editorRef.value?.destroy()
+            }
+        }
+
         Scaffold(
             topBar = {
                 CenterAlignedTopAppBar(


### PR DESCRIPTION
## Summary
- release VideoEditor when VideoTrimScreen leaves composition

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e53c303a0832c8bc21427e3c9541c