### PR TITLE
Add operation bar to trimming screen

### DIFF
--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -115,4 +115,10 @@
     <string name="original_sound_of">Original sound - %1$s</string>
     <string name="number_posts">%1$d posts</string>
 
+    <string name="play">Play</string>
+    <string name="pause">Pause</string>
+    <string name="rewind">Rewind</string>
+    <string name="forward">Forward</string>
+    <string name="fullscreen">Fullscreen</string>
+
 </resources>

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoOperationBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoOperationBar.kt
@@ -1,0 +1,87 @@
+package com.puskal.cameramedia.edit
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.puskal.theme.R
+import com.redevrx.video_trimmer.utils.TrimVideoUtils
+
+@Composable
+fun VideoOperationBar(
+    modifier: Modifier = Modifier,
+    isPlaying: Boolean,
+    currentPosition: Long,
+    totalDuration: Long,
+    onPlayPause: () -> Unit,
+    onRewind: () -> Unit = {},
+    onForward: () -> Unit = {},
+    onFullScreen: () -> Unit = {},
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = "${TrimVideoUtils.stringForTime(currentPosition)} / ${TrimVideoUtils.stringForTime(totalDuration)}",
+            style = MaterialTheme.typography.labelLarge,
+            color = Color.White
+        )
+
+        IconButton(onClick = onPlayPause) {
+            if (isPlaying) {
+                Icon(
+                    imageVector = Icons.Filled.Pause,
+                    contentDescription = stringResource(id = R.string.pause),
+                    tint = Color.White
+                )
+            } else {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_play),
+                    contentDescription = stringResource(id = R.string.play),
+                    tint = Color.White
+                )
+            }
+        }
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onRewind) {
+                Icon(
+                    imageVector = Icons.Filled.FastRewind,
+                    contentDescription = stringResource(id = R.string.rewind),
+                    tint = Color.White
+                )
+            }
+            IconButton(onClick = onForward) {
+                Icon(
+                    imageVector = Icons.Filled.FastForward,
+                    contentDescription = stringResource(id = R.string.forward),
+                    tint = Color.White
+                )
+            }
+            IconButton(onClick = onFullScreen) {
+                Icon(
+                    imageVector = Icons.Filled.Fullscreen,
+                    contentDescription = stringResource(id = R.string.fullscreen),
+                    tint = Color.White
+                )
+            }
+        }
+    }
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
@@ -22,10 +22,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.redevrx.video_trimmer.event.OnProgressVideoEvent
 import com.puskal.theme.R
 import com.puskal.theme.TikTokTheme
 import com.redevrx.video_trimmer.event.OnVideoEditedEvent
 import com.redevrx.video_trimmer.view.VideoEditor
+import com.puskal.cameramedia.edit.TimelineEditor
+import com.puskal.cameramedia.edit.VideoOperationBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,6 +43,9 @@ fun VideoTrimScreen(
         var saveRequested by remember { mutableStateOf(false) }
         var isSaving by remember { mutableStateOf(false) }
         val editorRef = remember { mutableStateOf<VideoEditor?>(null) }
+        var currentPosition by remember { mutableStateOf(0L) }
+        var totalDuration by remember { mutableStateOf(0L) }
+        var isPlaying by remember { mutableStateOf(false) }
 
         Scaffold(
             topBar = {
@@ -73,42 +79,64 @@ fun VideoTrimScreen(
                 TrimBottomBar(selectedTool = selectedTool) { selectedTool = it }
             }
         ) { padding ->
-            AndroidView(
-                factory = { ctx ->
-                    VideoEditor(ctx).apply {
-                        setDestinationPath(ctx.cacheDir.absolutePath)
-                        setVideoURI(Uri.parse(videoUri))
-                        setOnTrimVideoListener(object : OnVideoEditedEvent {
-                            override fun getResult(uri: Uri) {
-                                isSaving = false
-                                onSave(uri.toString())
-                            }
+            Column(modifier = Modifier.padding(padding)) {
+                AndroidView(
+                    factory = { ctx ->
+                        VideoEditor(ctx).apply {
+                            setDestinationPath(ctx.cacheDir.absolutePath)
+                            setVideoURI(Uri.parse(videoUri))
+                            setOnTrimVideoListener(object : OnVideoEditedEvent {
+                                override fun getResult(uri: Uri) {
+                                    isSaving = false
+                                    onSave(uri.toString())
+                                }
 
-                            override fun onError(message: String) {
-                                isSaving = false
-                            }
-                        })
-                        editorRef.value = this
-                    }
-                },
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-            ) { view ->
-                editorRef.value = view
-                if (saveRequested) {
-                    saveRequested = false
-                    isSaving = true
-                    view.saveVideo()
-                }
-            }
-
-            if (isSaving) {
-                LinearProgressIndicator(
+                                override fun onError(message: String) {
+                                    isSaving = false
+                                }
+                            })
+                            addOnProgressVideoEvent(object : OnProgressVideoEvent {
+                                override fun updateProgress(time: Float, max: Long, scale: Long) {
+                                    currentPosition = time.toLong()
+                                    totalDuration = max
+                                    isPlaying = this@apply.isPlaying
+                                }
+                            })
+                            editorRef.value = this
+                        }
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                        .weight(1f)
+                ) { view ->
+                    editorRef.value = view
+                    if (saveRequested) {
+                        saveRequested = false
+                        isSaving = true
+                        view.saveVideo()
+                    }
+                }
+
+                VideoOperationBar(
+                    isPlaying = isPlaying,
+                    currentPosition = currentPosition,
+                    totalDuration = totalDuration,
+                    onPlayPause = { editorRef.value?.togglePlayPause() },
+                    onRewind = { editorRef.value?.skipBackward(5000) },
+                    onForward = { editorRef.value?.skipForward(5000) }
                 )
+
+                TimelineEditor(
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                if (isSaving) {
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                    )
+                }
             }
         }
     }

--- a/feature/video-trimmer/src/main/java/com/redevrx/video_trimmer/view/VideoEditor.kt
+++ b/feature/video-trimmer/src/main/java/com/redevrx/video_trimmer/view/VideoEditor.kt
@@ -104,6 +104,27 @@ class VideoEditor @JvmOverloads constructor(
         setUpMargins()
     }
 
+    /**
+     * Register an [OnProgressVideoEvent] to receive progress updates of the currently
+     * playing video. The listener will be called whenever the player position
+     * changes.
+     */
+    fun addOnProgressVideoEvent(listener: OnProgressVideoEvent) {
+        mListeners.add(listener)
+    }
+
+    /** Current playback position of the player in milliseconds */
+    val currentPosition: Long
+        get() = if (this::mPlayer.isInitialized) mPlayer.currentPosition else 0L
+
+    /** Total duration of the loaded video in milliseconds */
+    val totalDuration: Long
+        get() = mDuration
+
+    /** Whether the player is currently playing */
+    val isPlaying: Boolean
+        get() = if (this::mPlayer.isInitialized) mPlayer.isPlaying else false
+
     @SuppressLint("ClickableViewAccessibility")
     private fun setUpListeners() {
         mListeners = ArrayList()
@@ -216,6 +237,22 @@ class VideoEditor @JvmOverloads constructor(
             mMessageHandler.sendEmptyMessage(SHOW_PROGRESS)
             mPlayer.play()
         }
+    }
+
+    fun togglePlayPause() {
+        onClickVideoPlayPause()
+    }
+
+    fun skipBackward(ms: Long) {
+        val newPos = (currentPosition - ms).coerceAtLeast(0L)
+        mPlayer.seekTo(newPos)
+        notifyProgressUpdate(false)
+    }
+
+    fun skipForward(ms: Long) {
+        val newPos = (currentPosition + ms).coerceAtMost(totalDuration)
+        mPlayer.seekTo(newPos)
+        notifyProgressUpdate(false)
     }
 
     fun onCancelClicked() {


### PR DESCRIPTION
## Summary
- expose progress from `VideoEditor` and add playback helpers
- add `VideoOperationBar` composable
- integrate operation bar and timeline editor in `VideoTrimScreen`
- add strings for new buttons

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e53d15260832cb59e3d6f02ea344c