### PR TITLE
Fix annotation dependency

### DIFF
--- a/feature/mp4compose/build.gradle
+++ b/feature/mp4compose/build.gradle
@@ -26,5 +26,6 @@ android {
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-  implementation "androidx.annotation:annotation:1.9.1"
+  // Align annotation dependency version with other modules
+  implementation "androidx.annotation:annotation:1.2.0"
 }


### PR DESCRIPTION
## Summary
- fix annotation dependency version in mp4compose

## Testing
- `./gradlew build --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e578e7304832c9e8bc701a9f00fd2