### PR TITLE
Fix video recorder crash

### DIFF
--- a/feature/cameracapture/src/main/java/com/otaliastudios/cameraview/engine/Camera2Engine.java
+++ b/feature/cameracapture/src/main/java/com/otaliastudios/cameraview/engine/Camera2Engine.java
@@ -904,8 +904,10 @@ public class Camera2Engine extends CameraBaseEngine implements
 
     private void doTakeVideo(@NonNull final VideoResult.Stub stub) {
         if (!(mVideoRecorder instanceof Full2VideoRecorder)) {
-            throw new IllegalStateException("doTakeVideo called, but video recorder " +
-                    "is not a Full2VideoRecorder! " + mVideoRecorder);
+            LOG.e("doTakeVideo", "Video recorder not prepared. Aborting recording.");
+            onVideoResult(null,
+                    new IllegalStateException("Video recorder is not a Full2VideoRecorder"));
+            return;
         }
         Full2VideoRecorder recorder = (Full2VideoRecorder) mVideoRecorder;
         try {


### PR DESCRIPTION
## Summary
- prevent crash when video recorder isn't ready by checking its type

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f25bdd5c0832c980a59cfb09576b6