### PR TITLE
Move timeline above operation bar

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
@@ -124,6 +124,10 @@ fun VideoTrimScreen(
                     }
                 }
 
+                TimelineEditor(
+                    modifier = Modifier.fillMaxWidth()
+                )
+
                 VideoOperationBar(
                     isPlaying = isPlaying,
                     currentPosition = currentPosition,
@@ -131,10 +135,6 @@ fun VideoTrimScreen(
                     onPlayPause = { editorRef.value?.togglePlayPause() },
                     onRewind = { editorRef.value?.skipBackward(5000) },
                     onForward = { editorRef.value?.skipForward(5000) }
-                )
-
-                TimelineEditor(
-                    modifier = Modifier.fillMaxWidth()
                 )
 
                 if (isSaving) {


### PR DESCRIPTION
## Summary
- move the `TimelineEditor` above the operation bar so the audio track shows first

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f266f6738832ca07f4d5ca5ef9688