### PR TITLE
Fix camera preview lifecycle binding

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -258,13 +258,17 @@ fun CameraPreview(
             setExperimental(true)
             setEngine(Engine.CAMERA2)
             setRequestPermissions(false)
-            setLifecycleOwner(lifecycleOwner)
             mode = Mode.PICTURE
             facing = defaultCameraFacing
             mapGesture(Gesture.PINCH, GestureAction.ZOOM)
             mapGesture(Gesture.TAP, GestureAction.AUTO_FOCUS)
             mapGesture(Gesture.LONG_TAP, GestureAction.TAKE_PICTURE)
         }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        cameraView.setLifecycleOwner(lifecycleOwner)
+        onDispose { cameraView.setLifecycleOwner(null) }
     }
     LaunchedEffect(selectedFilter) {
         cameraView.filter = selectedFilter.newInstance()


### PR DESCRIPTION
## Summary
- update CameraPreview to bind/unbind lifecycle in `DisposableEffect`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f26cec638832c8bf7eecb678805ea