### PR TITLE
Add filter toggle to VideoEditScreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This app consist of following modules:
 - common
 - core
 - filter - provides video filter capabilities accessed via the camera screen
+- `VideoEditScreen` supports filters only when the `enableFilters` parameter is
+  set to `true`.
 
 <img src="screenshots/tiktokcompose_modularization.jpg" width=760  />
 

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -43,7 +43,8 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
                 navController.navigate(
                     DestinationRoute.VIDEO_TRIM_ROUTE + "/" + Uri.encode(encoded)
                 )
-            }
+            },
+            enableFilters = true
         )
     }
 

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -1,6 +1,7 @@
 package com.puskal.cameramedia.edit
 
 import android.net.Uri
+import android.view.ViewGroup
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -23,6 +24,8 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import androidx.media3.ui.AspectRatioFrameLayout
 import com.puskal.theme.R
 import com.puskal.theme.TikTokTheme
 import com.puskal.theme.White
@@ -37,14 +40,15 @@ import com.puskal.cameramedia.edit.VideoFilterBottomSheet
 fun VideoEditScreen(
     videoUri: String,
     onClickBack: () -> Unit,
-    onTrimVideo: (String) -> Unit = {}
+    onTrimVideo: (String) -> Unit = {},
+    enableFilters: Boolean = false
 ) {
     TikTokTheme(darkTheme = true) {
         Scaffold { padding ->
             val context = LocalContext.current
             var showResizeMenu by remember { mutableStateOf(false) }
-            var showFilterSheet by remember { mutableStateOf(false) }
-            var selectedFilter by remember { mutableStateOf(VideoFilter.NONE) }
+            var showFilterSheet by remember(enableFilters) { mutableStateOf(false) }
+            var selectedFilter by remember(enableFilters) { mutableStateOf(VideoFilter.NONE) }
             val exoPlayer = remember(videoUri) {
                 // Initialize the player but delay preparing it until the surface is ready
                 ExoPlayer.Builder(context).build()
@@ -55,11 +59,38 @@ fun VideoEditScreen(
             // rendering surface becomes available
             var isPlayerPrepared by remember { mutableStateOf(false) }
 
-            val filterPlayerView = remember { GlFilterPlayerView(context) }
-            DisposableEffect(filterPlayerView) { onDispose { filterPlayerView.player = null } }
-            LaunchedEffect(exoPlayer) { filterPlayerView.player = exoPlayer }
-            LaunchedEffect(selectedFilter) {
-                filterPlayerView.setGlFilter(selectedFilter.create())
+            val playerView = if (enableFilters) {
+                remember { GlFilterPlayerView(context) }
+            } else {
+                remember {
+                    PlayerView(context).apply {
+                        useController = false
+                        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                        layoutParams = ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT
+                        )
+                    }
+                }
+            }
+            DisposableEffect(playerView) {
+                onDispose {
+                    when (playerView) {
+                        is GlFilterPlayerView -> playerView.player = null
+                        is PlayerView -> playerView.player = null
+                    }
+                }
+            }
+            LaunchedEffect(exoPlayer, playerView) {
+                when (playerView) {
+                    is GlFilterPlayerView -> playerView.player = exoPlayer
+                    is PlayerView -> playerView.player = exoPlayer
+                }
+            }
+            if (enableFilters) {
+                LaunchedEffect(selectedFilter) {
+                    (playerView as GlFilterPlayerView).setGlFilter(selectedFilter.create())
+                }
             }
 
             Box(
@@ -68,16 +99,30 @@ fun VideoEditScreen(
                     .fillMaxSize()
             ) {
                 AndroidView(
-                    factory = { filterPlayerView },
+                    factory = { playerView },
                     modifier = Modifier.fillMaxSize(),
                     update = { view ->
-                        view.player = exoPlayer
-                        if (!isPlayerPrepared && view.isAvailable) {
-                            exoPlayer.setMediaItem(MediaItem.fromUri(Uri.parse(videoUri)))
-                            exoPlayer.repeatMode = Player.REPEAT_MODE_ONE
-                            exoPlayer.prepare()
-                            exoPlayer.playWhenReady = true
-                            isPlayerPrepared = true
+                        when (view) {
+                            is GlFilterPlayerView -> {
+                                view.player = exoPlayer
+                                if (!isPlayerPrepared && view.isAvailable) {
+                                    exoPlayer.setMediaItem(MediaItem.fromUri(Uri.parse(videoUri)))
+                                    exoPlayer.repeatMode = Player.REPEAT_MODE_ONE
+                                    exoPlayer.prepare()
+                                    exoPlayer.playWhenReady = true
+                                    isPlayerPrepared = true
+                                }
+                            }
+                            is PlayerView -> {
+                                view.player = exoPlayer
+                                if (!isPlayerPrepared) {
+                                    exoPlayer.setMediaItem(MediaItem.fromUri(Uri.parse(videoUri)))
+                                    exoPlayer.repeatMode = Player.REPEAT_MODE_ONE
+                                    exoPlayer.prepare()
+                                    exoPlayer.playWhenReady = true
+                                    isPlayerPrepared = true
+                                }
+                            }
                         }
                     }
                 )
@@ -112,19 +157,20 @@ fun VideoEditScreen(
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
                         .padding(end = 16.dp),
+                    showFilters = enableFilters,
                     onToolSelected = {
                         when (it) {
                             VideoEditTool.CROP_RESIZE -> {
                                 showResizeMenu = !showResizeMenu
                             }
                             VideoEditTool.TRIM -> onTrimVideo(videoUri)
-                            VideoEditTool.FILTERS -> showFilterSheet = true
+                            VideoEditTool.FILTERS -> if (enableFilters) showFilterSheet = true
                             else -> {}
                         }
                     }
                 )
 
-                if (showFilterSheet) {
+                if (enableFilters && showFilterSheet) {
                     VideoFilterBottomSheet(
                         currentFilter = selectedFilter,
                         onSelectFilter = {

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -15,14 +16,22 @@ import androidx.compose.material3.Icon
 @Composable
 fun VideoEditToolBar(
     modifier: Modifier = Modifier,
+    showFilters: Boolean = true,
     onToolSelected: (VideoEditTool) -> Unit = {}
 ) {
+    val tools = remember(showFilters) {
+        if (showFilters) {
+            VideoEditTool.values().toList()
+        } else {
+            VideoEditTool.values().filterNot { it == VideoEditTool.FILTERS }
+        }
+    }
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        VideoEditTool.values().forEach { tool ->
+        tools.forEach { tool ->
             Icon(
                 imageVector = tool.icon,
                 contentDescription = null,


### PR DESCRIPTION
## Summary
- allow VideoEditScreen to optionally enable filters
- hide filter toolbar item and bottom sheet unless enabled
- update navigation to pass enableFilters flag
- document new parameter in README

## Testing
- `./gradlew assembleDebug -x lint` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f2b249584832c83fc7dc242c11dd7