### PR TITLE
Replace skip icons with undo/redo

### DIFF
--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -117,8 +117,8 @@
 
     <string name="play">Play</string>
     <string name="pause">Pause</string>
-    <string name="rewind">Rewind</string>
-    <string name="forward">Forward</string>
+    <string name="undo">Undo</string>
+    <string name="redo">Redo</string>
     <string name="fullscreen">Fullscreen</string>
 
 </resources>

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoOperationBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoOperationBar.kt
@@ -2,8 +2,8 @@ package com.puskal.cameramedia.edit
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FastForward
-import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.Redo
+import androidx.compose.material.icons.filled.Undo
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material3.Icon
@@ -27,8 +27,8 @@ fun VideoOperationBar(
     currentPosition: Long,
     totalDuration: Long,
     onPlayPause: () -> Unit,
-    onRewind: () -> Unit = {},
-    onForward: () -> Unit = {},
+    onUndo: () -> Unit = {},
+    onRedo: () -> Unit = {},
     onFullScreen: () -> Unit = {},
 ) {
     Row(
@@ -61,17 +61,17 @@ fun VideoOperationBar(
         }
 
         Row(verticalAlignment = Alignment.CenterVertically) {
-            IconButton(onClick = onRewind) {
+            IconButton(onClick = onUndo) {
                 Icon(
-                    imageVector = Icons.Filled.FastRewind,
-                    contentDescription = stringResource(id = R.string.rewind),
+                    imageVector = Icons.Filled.Undo,
+                    contentDescription = stringResource(id = R.string.undo),
                     tint = Color.White
                 )
             }
-            IconButton(onClick = onForward) {
+            IconButton(onClick = onRedo) {
                 Icon(
-                    imageVector = Icons.Filled.FastForward,
-                    contentDescription = stringResource(id = R.string.forward),
+                    imageVector = Icons.Filled.Redo,
+                    contentDescription = stringResource(id = R.string.redo),
                     tint = Color.White
                 )
             }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
@@ -132,9 +132,7 @@ fun VideoTrimScreen(
                     isPlaying = isPlaying,
                     currentPosition = currentPosition,
                     totalDuration = totalDuration,
-                    onPlayPause = { editorRef.value?.togglePlayPause() },
-                    onRewind = { editorRef.value?.skipBackward(5000) },
-                    onForward = { editorRef.value?.skipForward(5000) }
+                    onPlayPause = { editorRef.value?.togglePlayPause() }
                 )
 
                 if (isSaving) {


### PR DESCRIPTION
## Summary
- replace forward/rewind icons with undo/redo
- update string resources
- remove skip callbacks from video trim screen

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f2a0f8f9c832c98891de545700daa