### PR TITLE
Fix BuildConfig generation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,8 @@ android {
 
     buildFeatures {
         compose = true
+        // Ensure BuildConfig class is generated for accessing compile-time constants
+        buildConfig = true
     }
 
     composeOptions {


### PR DESCRIPTION
## Summary
- ensure BuildConfig is generated in `app` module

## Testing
- `./gradlew --version`

------
https://chatgpt.com/codex/tasks/task_e_687f68e68f2c832c8c50c3ff1c7426a1