### PR TITLE
Switch choose sound to bottom sheet

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -4,6 +4,8 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
+import com.google.accompanist.navigation.material.bottomSheet
 import androidx.navigation.navArgument
 import android.net.Uri
 import androidx.compose.runtime.collectAsState
@@ -18,11 +20,12 @@ import com.puskal.cameramedia.edit.VideoTrimScreen
 /**
  * Created by Puskal Khadka on 4/2/2023.
  */
+@OptIn(ExperimentalMaterialNavigationApi::class)
 fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
     composable(route = DestinationRoute.CAMERA_ROUTE) {
         CameraMediaScreen(navController)
     }
-    composable(route = DestinationRoute.CHOOSE_SOUND_ROUTE) {
+    bottomSheet(route = DestinationRoute.CHOOSE_SOUND_ROUTE) {
         com.puskal.cameramedia.sound.ChooseSoundScreen(navController)
     }
     composable(

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundScreen.kt
@@ -33,15 +33,15 @@ fun ChooseSoundScreen(
 ) {
     val viewState by viewModel.viewState.collectAsState()
 
-    Scaffold(topBar = {
-        TopBar(title = stringResource(id = R.string.sounds)) {
+    Column(
+        modifier = Modifier.fillMaxHeight(0.96f)
+    ) {
+        TopBar(navIcon = R.drawable.ic_cancel, title = stringResource(id = R.string.sounds)) {
             navController.navigateUp()
         }
-    }) { padding ->
+
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
+            modifier = Modifier.fillMaxSize()
         ) {
             viewState?.audios?.let { list ->
                 items(list) { audio ->


### PR DESCRIPTION
## Summary
- show the sound picker as a bottom sheet
- open bottom sheet using accompanist navigation when tapping the camera screen add audio button

## Testing
- `./gradlew test --no-watch-fs -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6ad4a168832c940e5190892978f4