### PR TITLE
Add mirror toggle for camera preview

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.navigation.NavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
@@ -252,6 +253,7 @@ fun CameraPreview(
     var defaultCameraFacing by remember { mutableStateOf(Facing.FRONT) }
     var showFilterSheet by remember { mutableStateOf(false) }
     var selectedFilter by remember { mutableStateOf(Filters.NONE) }
+    var isMirror by remember { mutableStateOf(false) }
 
     val cameraView = remember {
         CameraView(context).apply {
@@ -301,7 +303,12 @@ fun CameraPreview(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        AndroidView(factory = { cameraView }, modifier = Modifier.fillMaxSize())
+        AndroidView(
+            factory = { cameraView },
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer { scaleX = if (isMirror) -1f else 1f }
+        )
 
         Box(
             modifier = Modifier
@@ -363,6 +370,7 @@ fun CameraPreview(
                     CameraController.FILTERS -> {
                         showFilterSheet = true
                     }
+                    CameraController.MIRROR -> isMirror = !isMirror
                     else -> {}
                 }
             }


### PR DESCRIPTION
## Summary
- add `isMirror` state to `CameraPreview`
- flip preview with `graphicsLayer` when mirroring
- toggle mirror state from side controller

## Testing
- `./gradlew :feature:cameramedia:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f761b17d4832c98408cdb980a08d4