### PR TITLE
Adjust Video Trim header

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoTrimScreen.kt
@@ -57,7 +57,7 @@ fun VideoTrimScreen(
         Scaffold(
             topBar = {
                 CenterAlignedTopAppBar(
-                    title = { Text(text = stringResource(id = R.string.trim)) },
+                    title = {},
                     navigationIcon = {
                         IconButton(onClick = {
                             editorRef.value?.onCancelClicked()
@@ -79,7 +79,10 @@ fun VideoTrimScreen(
                             )
                         }
                     },
-                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color.Transparent)
+                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                        containerColor = Color.Transparent,
+                        scrolledContainerColor = Color.Transparent
+                    )
                 )
             },
             bottomBar = {


### PR DESCRIPTION
## Summary
- clean up Trim screen top bar by removing title and background

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8b1a83ac832cad6896edec7bed05