### PR TITLE
Add titles to video edit toolbar icons

### DIFF
--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -121,4 +121,10 @@
     <string name="redo">Redo</string>
     <string name="fullscreen">Fullscreen</string>
 
+    <string name="settings">Settings</string>
+    <string name="share">Share</string>
+    <string name="challenge">Challenge</string>
+    <string name="stickers">Stickers</string>
+    <string name="crop_resize">Crop/Resize</string>
+
 </resources>

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
@@ -16,19 +16,21 @@ import androidx.compose.material.icons.outlined.Brush
 import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Subtitles
 import androidx.compose.material.icons.outlined.Star
+import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.puskal.theme.R
 
-enum class VideoEditTool(val icon: ImageVector) {
-    SETTINGS(Icons.Filled.Settings),
-    SHARE(Icons.Filled.Share),
-    TRIM(Icons.Filled.ContentCut),
-    TEXT(Icons.Filled.TextFields),
-    CHALLENGE(Icons.Filled.Flag),
-    STICKERS(Icons.Filled.EmojiEmotions),
-    EFFECTS(Icons.Filled.Wallpaper),
-    FILTERS(Icons.Filled.InvertColors),
-    BEAUTY(Icons.Filled.Face),
-    CROP_RESIZE(Icons.Filled.Crop)
+enum class VideoEditTool(@StringRes val title: Int, val icon: ImageVector) {
+    SETTINGS(R.string.settings, Icons.Filled.Settings),
+    SHARE(R.string.share, Icons.Filled.Share),
+    TRIM(R.string.trim, Icons.Filled.ContentCut),
+    TEXT(R.string.text, Icons.Filled.TextFields),
+    CHALLENGE(R.string.challenge, Icons.Filled.Flag),
+    STICKERS(R.string.stickers, Icons.Filled.EmojiEmotions),
+    EFFECTS(R.string.effects, Icons.Filled.Wallpaper),
+    FILTERS(R.string.filters, Icons.Filled.InvertColors),
+    BEAUTY(R.string.beauty, Icons.Filled.Face),
+    CROP_RESIZE(R.string.crop_resize, Icons.Filled.Crop)
 }
 
 enum class ResizeMenuFeature(val icon: ImageVector) {

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
@@ -1,15 +1,20 @@
 package com.puskal.cameramedia.edit
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.Icon
 
@@ -32,14 +37,22 @@ fun VideoEditToolBar(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         tools.forEach { tool ->
-            Icon(
-                imageVector = tool.icon,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier
-                    .size(32.dp)
-                    .clickable { onToolSelected(tool) }
-            )
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Icon(
+                    imageVector = tool.icon,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clickable { onToolSelected(tool) }
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(id = tool.title),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.White
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- show text labels under icons in `VideoEditToolBar`
- provide string resources for new labels
- track labels in `VideoEditTool` enum

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f92275df0832cafa3b05b36b0836c