### PR TITLE
Update sticker icon

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
@@ -3,7 +3,7 @@ package com.puskal.cameramedia.edit
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCut
 import androidx.compose.material.icons.filled.Crop
-import androidx.compose.material.icons.filled.EmojiEmotions
+import androidx.compose.material.icons.filled.ArStickers
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.InvertColors
 import androidx.compose.material.icons.filled.Flag
@@ -24,7 +24,7 @@ enum class VideoEditTool(val icon: ImageVector) {
     TRIM(Icons.Filled.ContentCut),
     TEXT(Icons.Filled.TextFields),
     CHALLENGE(Icons.Filled.Flag),
-    STICKERS(Icons.Filled.EmojiEmotions),
+    STICKERS(Icons.Filled.ArStickers),
     EFFECTS(Icons.Filled.Wallpaper),
     FILTERS(Icons.Filled.InvertColors),
     BEAUTY(Icons.Filled.Face),


### PR DESCRIPTION
## Summary
- use `ArStickers` icon for stickers in edit screen

## Testing
- `./gradlew test --no-daemon` *(fails: Android core library plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f93206c3c832c816253f277eeb4ec