### PR TITLE
Expand video edit toolbar with scrollable more menu

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.InvertColors
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.TextFields
@@ -26,6 +27,7 @@ enum class VideoEditTool(val icon: ImageVector) {
     CHALLENGE(Icons.Filled.Flag),
     STICKERS(Icons.Filled.EmojiEmotions),
     EFFECTS(Icons.Filled.Wallpaper),
+    MORE(Icons.Filled.KeyboardArrowUp),
     FILTERS(Icons.Filled.InvertColors),
     BEAUTY(Icons.Filled.Face),
     CROP_RESIZE(Icons.Filled.Crop)

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -39,10 +39,10 @@ fun VideoEditScreen(
             val context = LocalContext.current
 
             /*************** STATE *****************/
-            var showResizeMenu   by remember { mutableStateOf(false) }
-            var showFilterSheet  by remember(enableFilters) { mutableStateOf(false) }
-            var selectedFilter   by remember(enableFilters) { mutableStateOf(VideoFilter.NONE) }
-            var isPlayerPrepared by remember { mutableStateOf(false) }
+            var showFilterSheet   by remember(enableFilters) { mutableStateOf(false) }
+            var selectedFilter    by remember(enableFilters) { mutableStateOf(VideoFilter.NONE) }
+            var isPlayerPrepared  by remember { mutableStateOf(false) }
+            var isToolbarExpanded by remember { mutableStateOf(false) }
 
             /*************** PLAYER *****************/
             val exoPlayer = remember(videoUri) {
@@ -178,30 +178,25 @@ fun VideoEditScreen(
                     onClickAddSound = { Log.d(TAG, "Add sound clicked") }
                 )
 
-                /*** Resize toolbar ***/
-                if (showResizeMenu) {
-                    ResizeToolBar(
-                        modifier = Modifier
-                            .align(Alignment.CenterEnd)
-                            .padding(end = 64.dp)
-                    )
-                }
-
                 /*** Main toolbar ***/
                 VideoEditToolBar(
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
                         .padding(end = 16.dp),
                     showFilters = enableFilters,
+                    expanded = isToolbarExpanded,
                     onToolSelected = { tool ->
                         Log.d(TAG, "Tool selected: $tool")
                         when (tool) {
-                            VideoEditTool.CROP_RESIZE -> showResizeMenu = !showResizeMenu
-                            VideoEditTool.TRIM        -> onTrimVideo(videoUri)
-                            VideoEditTool.FILTERS     -> if (enableFilters) showFilterSheet = true
-                            else                      -> {}
+                            VideoEditTool.TRIM    -> onTrimVideo(videoUri)
+                            VideoEditTool.FILTERS -> if (enableFilters) showFilterSheet = true
+                            else                  -> {}
                         }
-                    }
+                    },
+                    onFeatureSelected = { feature ->
+                        Log.d(TAG, "Feature selected: $feature")
+                    },
+                    onToggleExpand = { isToolbarExpanded = !isToolbarExpanded }
                 )
 
                 /*** Filter sheet ***/

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
@@ -4,11 +4,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.Icon
@@ -17,21 +18,36 @@ import androidx.compose.material3.Icon
 fun VideoEditToolBar(
     modifier: Modifier = Modifier,
     showFilters: Boolean = true,
-    onToolSelected: (VideoEditTool) -> Unit = {}
+    expanded: Boolean = false,
+    onToolSelected: (VideoEditTool) -> Unit = {},
+    onFeatureSelected: (ResizeMenuFeature) -> Unit = {},
+    onToggleExpand: () -> Unit = {}
 ) {
-    val tools = remember(showFilters) {
-        if (showFilters) {
-            VideoEditTool.values().toList()
-        } else {
-            VideoEditTool.values().filterNot { it == VideoEditTool.FILTERS }
-        }
+    val collapsedTools = remember(showFilters) {
+        listOf(
+            VideoEditTool.SETTINGS,
+            VideoEditTool.SHARE,
+            VideoEditTool.TRIM,
+            VideoEditTool.TEXT,
+            VideoEditTool.CHALLENGE,
+            VideoEditTool.STICKERS,
+            VideoEditTool.EFFECTS
+        )
     }
+    val extraTools = listOf(
+        VideoEditTool.FILTERS,
+        VideoEditTool.BEAUTY,
+        VideoEditTool.CROP_RESIZE
+    )
+
+    val scrollState = rememberScrollState()
+
     Column(
-        modifier = modifier,
+        modifier = if (expanded) modifier.verticalScroll(scrollState) else modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        tools.forEach { tool ->
+        collapsedTools.forEach { tool ->
             Icon(
                 imageVector = tool.icon,
                 contentDescription = null,
@@ -39,6 +55,43 @@ fun VideoEditToolBar(
                 modifier = Modifier
                     .size(32.dp)
                     .clickable { onToolSelected(tool) }
+            )
+        }
+
+        if (expanded) {
+            extraTools.forEach { tool ->
+                if (showFilters || tool != VideoEditTool.FILTERS) {
+                    Icon(
+                        imageVector = tool.icon,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clickable { onToolSelected(tool) }
+                    )
+                }
+            }
+            ResizeMenuFeature.values().forEach { feature ->
+                Icon(
+                    imageVector = feature.icon,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clickable {
+                            if (feature == ResizeMenuFeature.COLLAPSE_TOOLBAR) onToggleExpand()
+                            else onFeatureSelected(feature)
+                        }
+                )
+            }
+        } else {
+            Icon(
+                imageVector = VideoEditTool.MORE.icon,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier
+                    .size(32.dp)
+                    .clickable { onToggleExpand() }
             )
         }
     }


### PR DESCRIPTION
## Summary
- add MORE option to `VideoEditTool`
- make `VideoEditToolBar` expandable with scrolling
- integrate expanded menu into `VideoEditScreen`

## Testing
- `./gradlew test --no-daemon -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f953cae94832c8a2bf5133ba63ed5