### PR TITLE
Implement collapsible tools in video edit sidebar

### DIFF
--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -126,5 +126,9 @@
     <string name="challenge">Challenge</string>
     <string name="stickers">Stickers</string>
     <string name="crop_resize">Crop/Resize</string>
+    <string name="audio_transcript">Audio transcript</string>
+    <string name="enhance_video_quality">Enhance quality</string>
+    <string name="change_voice">Change voice</string>
+    <string name="drawing_painter">Drawing</string>
 
 </resources>

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditContract.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.InvertColors
 import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.TextFields
@@ -28,15 +29,16 @@ enum class VideoEditTool(@StringRes val title: Int, val icon: ImageVector) {
     CHALLENGE(R.string.challenge, Icons.Filled.Flag),
     STICKERS(R.string.stickers, Icons.Filled.EmojiEmotions),
     EFFECTS(R.string.effects, Icons.Filled.Wallpaper),
+    MORE(R.string.see_more, Icons.Filled.KeyboardArrowUp),
     FILTERS(R.string.filters, Icons.Filled.InvertColors),
     BEAUTY(R.string.beauty, Icons.Filled.Face),
     CROP_RESIZE(R.string.crop_resize, Icons.Filled.Crop)
 }
 
-enum class ResizeMenuFeature(val icon: ImageVector) {
-    AUTO_SUBTITLES(Icons.Outlined.Subtitles),
-    QUALITY_ENHANCEMENT(Icons.Outlined.Star),
-    VOICE_CHANGER(Icons.Outlined.Mic),
-    BRUSH_TOOL(Icons.Outlined.Brush),
-    COLLAPSE_TOOLBAR(Icons.Filled.KeyboardArrowDown)
+enum class ResizeMenuFeature(@StringRes val title: Int, val icon: ImageVector) {
+    AUTO_SUBTITLES(R.string.audio_transcript, Icons.Outlined.Subtitles),
+    QUALITY_ENHANCEMENT(R.string.enhance_video_quality, Icons.Outlined.Star),
+    VOICE_CHANGER(R.string.change_voice, Icons.Outlined.Mic),
+    BRUSH_TOOL(R.string.drawing_painter, Icons.Outlined.Brush),
+    COLLAPSE_TOOLBAR(R.string.hide, Icons.Filled.KeyboardArrowDown)
 }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -201,6 +201,13 @@ fun VideoEditScreen(
                             VideoEditTool.FILTERS     -> if (enableFilters) showFilterSheet = true
                             else                      -> {}
                         }
+                    },
+                    onFeatureSelected = { feature ->
+                        Log.d(TAG, "Feature selected: $feature")
+                        when (feature) {
+                            ResizeMenuFeature.COLLAPSE_TOOLBAR -> {}
+                            else -> {}
+                        }
                     }
                 )
 

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
@@ -1,41 +1,66 @@
 package com.puskal.cameramedia.edit
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.graphics.Color
-import androidx.compose.material3.Text
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.material3.Icon
 
 @Composable
 fun VideoEditToolBar(
     modifier: Modifier = Modifier,
     showFilters: Boolean = true,
-    onToolSelected: (VideoEditTool) -> Unit = {}
+    onToolSelected: (VideoEditTool) -> Unit = {},
+    onFeatureSelected: (ResizeMenuFeature) -> Unit = {}
 ) {
-    val tools = remember(showFilters) {
-        if (showFilters) {
-            VideoEditTool.values().toList()
-        } else {
-            VideoEditTool.values().filterNot { it == VideoEditTool.FILTERS }
+    var expanded by remember { mutableStateOf(false) }
+
+    val collapsedTools = remember(showFilters) {
+        listOf(
+            VideoEditTool.SETTINGS,
+            VideoEditTool.SHARE,
+            VideoEditTool.TRIM,
+            VideoEditTool.TEXT,
+            VideoEditTool.CHALLENGE,
+            VideoEditTool.STICKERS,
+            VideoEditTool.EFFECTS,
+            VideoEditTool.MORE
+        )
+    }
+
+    val expandedTools = remember(showFilters) {
+        buildList {
+            add(VideoEditTool.SETTINGS)
+            add(VideoEditTool.SHARE)
+            add(VideoEditTool.TRIM)
+            add(VideoEditTool.TEXT)
+            add(VideoEditTool.CHALLENGE)
+            add(VideoEditTool.STICKERS)
+            add(VideoEditTool.EFFECTS)
+            if (showFilters) add(VideoEditTool.FILTERS)
+            add(VideoEditTool.BEAUTY)
+            add(VideoEditTool.CROP_RESIZE)
         }
     }
+
     Column(
-        modifier = modifier,
+        modifier = if (expanded.value) modifier.verticalScroll(rememberScrollState()) else modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        val tools = if (expanded.value) expandedTools else collapsedTools
         tools.forEach { tool ->
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Icon(
@@ -44,7 +69,13 @@ fun VideoEditToolBar(
                     tint = Color.White,
                     modifier = Modifier
                         .size(32.dp)
-                        .clickable { onToolSelected(tool) }
+                        .clickable {
+                            if (tool == VideoEditTool.MORE) {
+                                expanded.value = true
+                            } else {
+                                onToolSelected(tool)
+                            }
+                        }
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
@@ -52,6 +83,32 @@ fun VideoEditToolBar(
                     style = MaterialTheme.typography.labelSmall,
                     color = Color.White
                 )
+            }
+        }
+        if (expanded.value) {
+            ResizeMenuFeature.values().forEach { feature ->
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        imageVector = feature.icon,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clickable {
+                                if (feature == ResizeMenuFeature.COLLAPSE_TOOLBAR) {
+                                    expanded.value = false
+                                } else {
+                                    onFeatureSelected(feature)
+                                }
+                            }
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(id = feature.title),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.White
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow expandable toolbar inside video editing flow
- show new tool labels
- wire up more and hide buttons
- add string resources for new features

## Testing
- `./gradlew :app:assembleDebug --console=plain --no-daemon --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f97284094832c8c6595a2de8c1dcd