### PR TITLE
Add audio selection bottom sheet

### DIFF
--- a/common/theme/src/main/res/drawable/ic_music_off.xml
+++ b/common/theme/src/main/res/drawable/ic_music_off.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#ffffff" android:pathData="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zM19 12c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/>
+</vector>

--- a/common/theme/src/main/res/drawable/ic_volume.xml
+++ b/common/theme/src/main/res/drawable/ic_volume.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#ffffff" android:pathData="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/>
+</vector>

--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -130,5 +130,14 @@
     <string name="enhance_video_quality">Enhance quality</string>
     <string name="change_voice">Change voice</string>
     <string name="drawing_painter">Drawing</string>
+    <string name="original_sound">Original Sound</string>
+    <string name="music_off">Music Off</string>
+    <string name="volume">Volume</string>
+    <string name="subtitle">Subtitle</string>
+    <string name="import_audio">Import Audio</string>
+    <string name="recommended">Recommended</string>
+    <string name="hot">Hot</string>
+    <string name="favorites">Favorites</string>
+    <string name="used">Used</string>
 
 </resources>

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -26,7 +26,9 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
         CameraMediaScreen(navController)
     }
     bottomSheet(route = DestinationRoute.CHOOSE_SOUND_ROUTE) {
-        com.puskal.cameramedia.sound.ChooseSoundScreen(navController)
+        com.puskal.cameramedia.sound.AudioBottomSheet(onDismiss = {
+            navController.navigateUp()
+        })
     }
     composable(
         route = FORMATTED_VIDEO_EDIT_ROUTE,

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -1,0 +1,164 @@
+package com.puskal.cameramedia.sound
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.puskal.theme.GrayMainColor
+import com.puskal.theme.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AudioBottomSheet(
+    onDismiss: () -> Unit,
+    viewModel: ChooseSoundViewModel = hiltViewModel()
+) {
+    val viewState by viewModel.viewState.collectAsState()
+    var search by remember { mutableStateOf("") }
+    var selectedTab by remember { mutableStateOf(0) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(width = 36.dp, height = 4.dp)
+                        .background(color = GrayMainColor, shape = RoundedCornerShape(2.dp))
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = search,
+                onValueChange = { search = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_search),
+                        contentDescription = null
+                    )
+                },
+                placeholder = { Text(text = stringResource(id = R.string.search)) }
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                val tabs = listOf(
+                    stringResource(id = R.string.recommended),
+                    stringResource(id = R.string.hot),
+                    stringResource(id = R.string.favorites),
+                    stringResource(id = R.string.used)
+                )
+                TabRow(
+                    selectedTabIndex = selectedTab,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    tabs.forEachIndexed { index, title ->
+                        Tab(
+                            selected = selectedTab == index,
+                            onClick = { selectedTab = index },
+                            text = { Text(text = title) }
+                        )
+                    }
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(end = 16.dp, start = 8.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_plus),
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(text = stringResource(id = R.string.import_audio))
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            LazyColumn(
+                modifier = Modifier.weight(1f, fill = false)
+            ) {
+                viewState?.audioFiles?.let { list ->
+                    items(list) { audio ->
+                        AudioRow(audio)
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BottomAction(text = stringResource(id = R.string.original_sound), icon = R.drawable.ic_music_note)
+                BottomAction(text = stringResource(id = R.string.music_off), icon = R.drawable.ic_music_off)
+                BottomAction(text = stringResource(id = R.string.volume), icon = R.drawable.ic_volume)
+                BottomAction(text = stringResource(id = R.string.subtitle), icon = R.drawable.ic_auto_subtitles)
+            }
+        }
+    }
+}
+
+@Composable
+private fun BottomAction(text: String, icon: Int) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Icon(painter = painterResource(id = icon), contentDescription = text, tint = Color.White)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(text = text, style = MaterialTheme.typography.labelSmall, color = Color.White)
+    }
+}
+
+@Composable
+private fun AudioRow(name: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_music_note),
+            contentDescription = null,
+            modifier = Modifier.size(56.dp),
+            tint = Color.White
+        )
+        Text(
+            text = name,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.White,
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 12.dp)
+        )
+        TextButton(onClick = { }) {
+            Text(text = stringResource(id = R.string.use_this_sound))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AudioBottomSheet` composable for sound picker
- include search field, tabs, import button and bottom toolbar
- add drawable resources for music off and volume icons
- add related strings
- hook the bottom sheet into navigation

## Testing
- `./gradlew :feature:cameramedia:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f9ae5f44c832c9599e21641e9a9a9