### PR TITLE
Update audio search field style

### DIFF
--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <!-- search -->
     <string name="find_related_content">Find related content</string>
     <string name="search">Search</string>
+    <string name="search_singer_music_lyric_emotion">Search singer, music, lyric, emotion</string>
 
     <!-- inbox -->
     <string name="message_and_notifications_will_appear_here">Message and notifications will appear here</string>

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.puskal.theme.GrayMainColor
+import com.puskal.theme.Gray
 import com.puskal.theme.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -55,7 +56,16 @@ fun AudioBottomSheet(
                         contentDescription = null
                     )
                 },
-                placeholder = { Text(text = stringResource(id = R.string.search)) }
+                placeholder = {
+                    Text(text = stringResource(id = R.string.search_singer_music_lyric_emotion))
+                },
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    textColor = Gray,
+                    placeholderColor = Gray,
+                    focusedLeadingIconColor = Gray,
+                    unfocusedLeadingIconColor = Gray,
+                    containerColor = GrayMainColor
+                )
             )
 
             Spacer(modifier = Modifier.height(12.dp))


### PR DESCRIPTION
## Summary
- add new string resource `search_singer_music_lyric_emotion`
- use the new string as placeholder text in `AudioBottomSheet`
- style the search field with gray colors via `TextFieldDefaults.outlinedTextFieldColors`

## Testing
- `./gradlew tasks --all`
- `./gradlew lint` *(fails: SDK location not found)*
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68808bbbd0d4832cb9a5a2ba98bfb9f2