### PR TITLE
Fix audio bottom sheet layout

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -99,7 +99,7 @@ fun AudioBottomSheet(
             Spacer(modifier = Modifier.height(8.dp))
 
             LazyColumn(
-                modifier = Modifier.weight(1f, fill = false)
+                modifier = Modifier.weight(1f, fill = true)
             ) {
                 viewState?.audioFiles?.let { list ->
                     items(list) { audio ->
@@ -129,9 +129,9 @@ fun AudioBottomSheet(
 @Composable
 private fun BottomAction(text: String, icon: Int) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Icon(painter = painterResource(id = icon), contentDescription = text, tint = Color.White)
+        Icon(painter = painterResource(id = icon), contentDescription = text, tint = Color.Black)
         Spacer(modifier = Modifier.height(4.dp))
-        Text(text = text, style = MaterialTheme.typography.labelSmall, color = Color.White)
+        Text(text = text, style = MaterialTheme.typography.labelSmall, color = Color.Black)
     }
 }
 


### PR DESCRIPTION
## Summary
- update LazyColumn weight to fill available space
- set black icon and text color in bottom actions

## Testing
- `./gradlew help` *(fails: Gradle download started but environment blocked further execution)*

------
https://chatgpt.com/codex/tasks/task_e_68808bbf364c832cabdb5974ab5a04f5