### PR TITLE
Add audio duration display

### DIFF
--- a/data/src/main/java/com/puskal/data/model/AudioModel.kt
+++ b/data/src/main/java/com/puskal/data/model/AudioModel.kt
@@ -9,6 +9,7 @@ data class AudioModel(
     val audioAuthor:UserModel,
     val numberOfPost:Long,
     val originalVideoUrl:String,
+    val duration: String,
 ){
     fun parseCoverImage(): String =
         if (audioCoverImage.startsWith("http")) audioCoverImage

--- a/data/src/main/java/com/puskal/data/source/AudioDataSource.kt
+++ b/data/src/main/java/com/puskal/data/source/AudioDataSource.kt
@@ -15,28 +15,32 @@ object AudioDataSource {
             isOriginal = true,
             audioAuthor = charliePuth,
             numberOfPost = 239000,
-            originalVideoUrl = "charlieputh_vid1.mp4"
+            originalVideoUrl = "charlieputh_vid1.mp4",
+            duration = "02:10"
         ),
         AudioModel(
             audioCoverImage = "img2.jpg",
             isOriginal = true,
             audioAuthor = kylieJenner,
             numberOfPost = 42000,
-            originalVideoUrl = "kylie_vid2.mp4"
+            originalVideoUrl = "kylie_vid2.mp4",
+            duration = "01:45"
         ),
         AudioModel(
             audioCoverImage = "img3.jpg",
             isOriginal = true,
             audioAuthor = duaLipa,
             numberOfPost = 120340,
-            originalVideoUrl = "dua_vid1.mp4"
+            originalVideoUrl = "dua_vid1.mp4",
+            duration = "03:05"
         ),
         AudioModel(
             audioCoverImage = "img4.jpg",
             isOriginal = true,
             audioAuthor = taylor,
             numberOfPost = 15200,
-            originalVideoUrl = "taylor_vid1.mp4"
+            originalVideoUrl = "taylor_vid1.mp4",
+            duration = "02:30"
         )
     )
 

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.puskal.data.model.AudioModel
 import com.puskal.theme.GrayMainColor
 import com.puskal.theme.R
 
@@ -136,7 +137,7 @@ private fun BottomAction(text: String, icon: Int) {
 }
 
 @Composable
-private fun AudioRow(name: String) {
+private fun AudioRow(audio: AudioModel) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -149,14 +150,22 @@ private fun AudioRow(name: String) {
             modifier = Modifier.size(56.dp),
             tint = Color.White
         )
-        Text(
-            text = name,
-            style = MaterialTheme.typography.bodyMedium,
-            color = Color.White,
+        Column(
             modifier = Modifier
                 .weight(1f)
                 .padding(start = 12.dp)
-        )
+        ) {
+            Text(
+                text = audio.originalVideoUrl.substringBeforeLast('.'),
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.White
+            )
+            Text(
+                text = "${audio.audioAuthor.fullName} • ${audio.duration}",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.White
+            )
+        }
         TextButton(onClick = { }) {
             Text(text = stringResource(id = R.string.use_this_sound))
         }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundContract.kt
@@ -1,7 +1,9 @@
 package com.puskal.cameramedia.sound
 
+import com.puskal.data.model.AudioModel
+
 data class ViewState(
-    val audioFiles: List<String>? = null
+    val audioFiles: List<AudioModel>? = null
 )
 
 sealed class SoundEvent

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundScreen.kt
@@ -17,6 +17,7 @@ import androidx.navigation.NavController
 import com.puskal.composable.TopBar
 import com.puskal.core.DestinationRoute
 import com.puskal.theme.R
+import com.puskal.data.model.AudioModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,7 +47,7 @@ fun ChooseSoundScreen(
 }
 
 @Composable
-private fun AudioRow(name: String) {
+private fun AudioRow(audio: AudioModel) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -58,13 +59,18 @@ private fun AudioRow(name: String) {
             contentDescription = null,
             modifier = Modifier.size(56.dp)
         )
-        Text(
-            text = name,
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier
-                .weight(1f)
-                .padding(start = 12.dp)
-        )
+        Column(modifier = Modifier
+            .weight(1f)
+            .padding(start = 12.dp)) {
+            Text(
+                text = audio.originalVideoUrl.substringBeforeLast('.'),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                text = "${audio.audioAuthor.fullName} • ${audio.duration}",
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
         TextButton(onClick = { }) {
             Text(text = stringResource(id = R.string.use_this_sound))
         }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundViewModel.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundViewModel.kt
@@ -3,6 +3,7 @@ package com.puskal.cameramedia.sound
 import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.puskal.core.base.BaseViewModel
+import com.puskal.domain.cameramedia.GetAudioUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
@@ -10,7 +11,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ChooseSoundViewModel @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val getAudioUseCase: GetAudioUseCase
 ) : BaseViewModel<ViewState, SoundEvent>() {
 
     init {
@@ -19,12 +21,9 @@ class ChooseSoundViewModel @Inject constructor(
 
     private fun fetchAudios() {
         viewModelScope.launch {
-            // AssetManager.list returns an array. Convert it to a List so that the
-            // null coalescing expression keeps a consistent type and we can
-            // safely use collection operations like `map`.
-            val files: List<String> =
-                context.assets.list("audios")?.toList()?.sorted() ?: emptyList()
-            updateState(ViewState(audioFiles = files.map { it.substringBeforeLast('.') }))
+            getAudioUseCase().collect {
+                updateState(ViewState(audioFiles = it))
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- extend `AudioModel` with a new `duration` field
- add durations to `AudioDataSource` sample list
- load audios through `GetAudioUseCase` in `ChooseSoundViewModel`
- display author and duration in sound list rows

## Testing
- `./gradlew tasks --all` *(fails: Gradle needs Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68808bc1e464832c99afda3931c1fcd6