### PR TITLE
Integrate AudioModel with sound picker

### DIFF
--- a/core/src/main/java/com/puskal/core/DestinationRoute.kt
+++ b/core/src/main/java/com/puskal/core/DestinationRoute.kt
@@ -36,6 +36,7 @@ object DestinationRoute {
         const val USER_ID = "user_id"
         const val VIDEO_INDEX = "video_index"
         const val VIDEO_URI = "video_uri"
+        const val AUDIO = "audio"
     }
 }
 

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -16,6 +16,8 @@ import com.puskal.core.DestinationRoute.FORMATTED_VIDEO_TRIM_ROUTE
 import com.puskal.core.DestinationRoute.PassedKey
 import com.puskal.cameramedia.edit.VideoEditScreen
 import com.puskal.cameramedia.edit.VideoTrimScreen
+import com.puskal.data.model.AudioModel
+import com.google.gson.Gson
 
 /**
  * Created by Puskal Khadka on 4/2/2023.
@@ -26,9 +28,16 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
         CameraMediaScreen(navController)
     }
     bottomSheet(route = DestinationRoute.CHOOSE_SOUND_ROUTE) {
-        com.puskal.cameramedia.sound.AudioBottomSheet(onDismiss = {
-            navController.navigateUp()
-        })
+        com.puskal.cameramedia.sound.AudioBottomSheet(
+            onDismiss = { navController.navigateUp() },
+            onAudioSelected = { audio ->
+                navController.previousBackStackEntry?.savedStateHandle?.set(
+                    PassedKey.AUDIO,
+                    Gson().toJson(audio)
+                )
+                navController.navigateUp()
+            }
+        )
     }
     composable(
         route = FORMATTED_VIDEO_EDIT_ROUTE,
@@ -41,8 +50,14 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
             .savedStateHandle
             .getStateFlow(PassedKey.VIDEO_URI, argUri)
             .collectAsState()
+        val audioJson by backStackEntry
+            .savedStateHandle
+            .getStateFlow<String?>(PassedKey.AUDIO, null)
+            .collectAsState()
+        val audioModel: AudioModel? = audioJson?.let { Gson().fromJson(it, AudioModel::class.java) }
         VideoEditScreen(
             videoUri = videoUri,
+            audio = audioModel,
             onClickBack = { navController.navigateUp() },
             onTrimVideo = { encoded ->
                 navController.navigate(

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -19,6 +19,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import com.puskal.cameramedia.MusicBarLayout
+import com.puskal.data.model.AudioModel
 import com.puskal.theme.R
 import com.puskal.theme.TikTokTheme
 import com.puskal.theme.White
@@ -30,6 +31,7 @@ private const val TAG = "VideoEditScreen"
 @Composable
 fun VideoEditScreen(
     videoUri: String,
+    audio: AudioModel? = null,
     onClickBack: () -> Unit,
     onTrimVideo: (String) -> Unit = {},
     enableFilters: Boolean = false
@@ -37,6 +39,7 @@ fun VideoEditScreen(
     TikTokTheme(darkTheme = true) {
         Scaffold { padding ->
             val context = LocalContext.current
+            Log.d(TAG, "Selected audio = ${'$'}audio")
 
             /*************** STATE *****************/
             var showResizeMenu   by remember { mutableStateOf(false) }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -16,11 +16,13 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.puskal.theme.GrayMainColor
 import com.puskal.theme.R
+import com.puskal.data.model.AudioModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AudioBottomSheet(
     onDismiss: () -> Unit,
+    onAudioSelected: (AudioModel) -> Unit = {},
     viewModel: ChooseSoundViewModel = hiltViewModel()
 ) {
     val viewState by viewModel.viewState.collectAsState()
@@ -103,7 +105,7 @@ fun AudioBottomSheet(
             ) {
                 viewState?.audioFiles?.let { list ->
                     items(list) { audio ->
-                        AudioRow(audio)
+                        AudioRow(audio) { onAudioSelected(it) }
                     }
                 }
             }
@@ -136,7 +138,7 @@ private fun BottomAction(text: String, icon: Int) {
 }
 
 @Composable
-private fun AudioRow(name: String) {
+private fun AudioRow(audio: AudioModel, onSelect: (AudioModel) -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -150,14 +152,14 @@ private fun AudioRow(name: String) {
             tint = Color.White
         )
         Text(
-            text = name,
+            text = audio.audioAuthor.fullName,
             style = MaterialTheme.typography.bodyMedium,
             color = Color.White,
             modifier = Modifier
                 .weight(1f)
                 .padding(start = 12.dp)
         )
-        TextButton(onClick = { }) {
+        TextButton(onClick = { onSelect(audio) }) {
             Text(text = stringResource(id = R.string.use_this_sound))
         }
     }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundContract.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundContract.kt
@@ -1,7 +1,9 @@
 package com.puskal.cameramedia.sound
 
+import com.puskal.data.model.AudioModel
+
 data class ViewState(
-    val audioFiles: List<String>? = null
+    val audioFiles: List<AudioModel>? = null
 )
 
 sealed class SoundEvent

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundScreen.kt
@@ -16,6 +16,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.puskal.composable.TopBar
 import com.puskal.core.DestinationRoute
+import com.puskal.data.model.AudioModel
 import com.puskal.theme.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -46,7 +47,7 @@ fun ChooseSoundScreen(
 }
 
 @Composable
-private fun AudioRow(name: String) {
+private fun AudioRow(audio: AudioModel) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -59,7 +60,7 @@ private fun AudioRow(name: String) {
             modifier = Modifier.size(56.dp)
         )
         Text(
-            text = name,
+            text = audio.audioAuthor.fullName,
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier
                 .weight(1f)

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundViewModel.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/ChooseSoundViewModel.kt
@@ -1,16 +1,15 @@
 package com.puskal.cameramedia.sound
 
-import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.puskal.core.base.BaseViewModel
+import com.puskal.domain.cameramedia.GetAudioUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ChooseSoundViewModel @Inject constructor(
-    @ApplicationContext private val context: Context
+    private val getAudioUseCase: GetAudioUseCase
 ) : BaseViewModel<ViewState, SoundEvent>() {
 
     init {
@@ -19,12 +18,9 @@ class ChooseSoundViewModel @Inject constructor(
 
     private fun fetchAudios() {
         viewModelScope.launch {
-            // AssetManager.list returns an array. Convert it to a List so that the
-            // null coalescing expression keeps a consistent type and we can
-            // safely use collection operations like `map`.
-            val files: List<String> =
-                context.assets.list("audios")?.toList()?.sorted() ?: emptyList()
-            updateState(ViewState(audioFiles = files.map { it.substringBeforeLast('.') }))
+            getAudioUseCase().collect { audios ->
+                updateState(ViewState(audioFiles = audios))
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- use AudioModel list in sound picker state
- fetch audios using GetAudioUseCase
- update bottom sheet to return selected AudioModel
- store selected audio in nav SavedStateHandle and forward to VideoEditScreen
- plumb audio info to editor screen

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68808bc9c240832ca7cce3b5366d60eb