### PR TITLE
Add audio playback to bottom sheet

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -1,6 +1,7 @@
 package com.puskal.cameramedia.sound
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -10,6 +11,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -17,6 +19,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCut
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
 import com.puskal.data.model.AudioModel
 import com.puskal.theme.GrayMainColor
 import com.puskal.theme.R
@@ -30,6 +34,14 @@ fun AudioBottomSheet(
     val viewState by viewModel.viewState.collectAsState()
     var search by remember { mutableStateOf("") }
     var selectedTab by remember { mutableStateOf(0) }
+
+    val context = LocalContext.current
+    val exoPlayer = remember { ExoPlayer.Builder(context).build() }
+    var playingItem by remember { mutableStateOf<AudioModel?>(null) }
+
+    DisposableEffect(Unit) {
+        onDispose { exoPlayer.release() }
+    }
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.fillMaxWidth()) {
@@ -109,7 +121,24 @@ fun AudioBottomSheet(
             ) {
                 viewState?.audioFiles?.let { list ->
                     items(list) { audio ->
-                        AudioRow(audio)
+                        val isPlaying = playingItem == audio
+                        AudioRow(
+                            audio = audio,
+                            isPlaying = isPlaying,
+                            onClick = {
+                                if (isPlaying) {
+                                    exoPlayer.stop()
+                                    playingItem = null
+                                } else {
+                                    exoPlayer.setMediaItem(
+                                        MediaItem.fromUri("asset:///videos/${audio.originalVideoUrl}")
+                                    )
+                                    exoPlayer.prepare()
+                                    exoPlayer.playWhenReady = true
+                                    playingItem = audio
+                                }
+                            }
+                        )
                     }
                 }
             }
@@ -142,10 +171,15 @@ private fun BottomAction(text: String, icon: Int) {
 }
 
 @Composable
-private fun AudioRow(audio: AudioModel) {
+private fun AudioRow(
+    audio: AudioModel,
+    isPlaying: Boolean,
+    onClick: () -> Unit
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -153,7 +187,7 @@ private fun AudioRow(audio: AudioModel) {
             painter = painterResource(id = R.drawable.ic_music_note),
             contentDescription = null,
             modifier = Modifier.size(56.dp),
-            tint = Color.White
+            tint = if (isPlaying) MaterialTheme.colorScheme.primary else Color.White
         )
         Text(
             text = audio.audioAuthor.fullName,


### PR DESCRIPTION
## Summary
- introduce ExoPlayer in `AudioBottomSheet`
- keep track of currently playing item
- start/stop playback when a row is clicked

## Testing
- `./gradlew help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68809d349124832c8effecd85e1eedb6