### PR TITLE
Fix camera mirroring by updating CameraView scale

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -283,6 +283,9 @@ fun CameraPreview(
     LaunchedEffect(defaultCameraFacing) {
         cameraView.facing = defaultCameraFacing
     }
+    LaunchedEffect(isMirror) {
+        cameraView.scaleX = if (isMirror) -1f else 1f
+    }
     var isRecording by remember { mutableStateOf(false) }
     var recordedFile by remember { mutableStateOf<File?>(null) }
 


### PR DESCRIPTION
## Summary
- update CameraPreview to set `cameraView.scaleX` whenever mirroring state changes

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a19effd0832c8324e02373f08c92