### PR TITLE
Clarify mirror control behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This app consist of following modules:
 
 `VideoEditScreen` supports filters only when the `enableFilters` parameter is
 set to `true`.
+`Mirror` in the camera preview works only when using the front camera.
 
 <img src="screenshots/tiktokcompose_modularization.jpg" width=760  />
 

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/tabs/CameraScreen.kt
@@ -564,27 +564,39 @@ fun CameraSideControllerSection(
     defaultCameraFacing: Facing,
     onClickController: (CameraController) -> Unit
 ) {
-    val controllers =
-        if (defaultCameraFacing == Facing.BACK) CameraController.values()
-            .toMutableList().apply { remove(CameraController.MIRROR) }
-        else CameraController.values().toMutableList().apply { remove(CameraController.FLASH) }
+    val controllers = CameraController.values().toMutableList().apply {
+        if (defaultCameraFacing == Facing.FRONT) remove(CameraController.FLASH)
+    }
+
+    val isMirrorEnabled = defaultCameraFacing == Facing.FRONT
 
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(14.dp)) {
-        controllers.forEach {
-            ControllerItem(it, onClickController)
+        controllers.forEach { controller ->
+            val enabled = when (controller) {
+                CameraController.MIRROR -> isMirrorEnabled
+                CameraController.FLASH -> defaultCameraFacing == Facing.BACK
+                else -> true
+            }
+            ControllerItem(controller, enabled, onClickController)
         }
     }
 }
 
 @Composable
 fun ControllerItem(
-    cameraController: CameraController, onClickController: (CameraController) -> Unit
+    cameraController: CameraController,
+    enabled: Boolean = true,
+    onClickController: (CameraController) -> Unit
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(
-        4.dp, alignment = Alignment.CenterVertically
-    ), horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.clickable {
-        onClickController(cameraController)
-    }) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp, alignment = Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .alpha(if (enabled) 1f else 0.4f)
+            .clickable(enabled = enabled) {
+                onClickController(cameraController)
+            }
+    ) {
         Icon(
             imageVector = cameraController.icon(),
             contentDescription = null,


### PR DESCRIPTION
## Summary
- keep mirror icon visible even when the back camera is active
- disable the mirror icon when the back camera is used
- document that mirror only works with the front camera

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a19fae38832cb37d618c7557f8d1