### PR TITLE
Fix OutlinedTextField colors usage

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -79,11 +79,14 @@ fun AudioBottomSheet(
                     Text(text = stringResource(id = R.string.search_singer_music_lyric_emotion))
                 },
                 colors = OutlinedTextFieldDefaults.colors(
-                    textColor = Gray,
-                    placeholderColor = Gray,
+                    focusedTextColor = Gray,
+                    unfocusedTextColor = Gray,
+                    focusedPlaceholderColor = Gray,
+                    unfocusedPlaceholderColor = Gray,
                     focusedLeadingIconColor = Gray,
                     unfocusedLeadingIconColor = Gray,
-                    containerColor = GrayMainColor
+                    focusedContainerColor = GrayMainColor,
+                    unfocusedContainerColor = GrayMainColor
                 )
             )
 


### PR DESCRIPTION
## Summary
- update `AudioBottomSheet` to use new `OutlinedTextFieldDefaults.colors` API

## Testing
- `gradlew :feature:cameramedia:compileDebugKotlin` *(fails: network or missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880ab5c6ec4832c9a25136c4060aeec