### PR TITLE
Enable audio picker from edit screen

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -49,6 +49,9 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
                     DestinationRoute.VIDEO_TRIM_ROUTE + "/" + Uri.encode(encoded)
                 )
             },
+            onClickAddSound = {
+                navController.navigate(DestinationRoute.CHOOSE_SOUND_ROUTE)
+            },
             enableFilters = true
         )
     }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -32,6 +32,7 @@ fun VideoEditScreen(
     videoUri: String,
     onClickBack: () -> Unit,
     onTrimVideo: (String) -> Unit = {},
+    onClickAddSound: () -> Unit = {},
     enableFilters: Boolean = false
 ) {
     TikTokTheme(darkTheme = true) {
@@ -175,7 +176,10 @@ fun VideoEditScreen(
                     modifier = Modifier
                         .align(Alignment.TopCenter)
                         .padding(top = 32.dp),
-                    onClickAddSound = { Log.d(TAG, "Add sound clicked") }
+                    onClickAddSound = {
+                        Log.d(TAG, "Add sound clicked")
+                        onClickAddSound()
+                    }
                 )
 
                 /*** Resize toolbar ***/


### PR DESCRIPTION
## Summary
- expose `onClickAddSound` in `VideoEditScreen`
- trigger the existing audio bottom sheet when tapping the Add Sound bar

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d9039ab0832cb995deb3fbe74c5f