### PR TITLE
Implement shuffled audio lists from assets

### DIFF
--- a/data/src/main/java/com/puskal/data/repository/camermedia/AudioRepository.kt
+++ b/data/src/main/java/com/puskal/data/repository/camermedia/AudioRepository.kt
@@ -1,12 +1,16 @@
 package com.puskal.data.repository.camermedia
 
+import android.content.Context
 import com.puskal.data.model.AudioModel
 import com.puskal.data.source.AudioDataSource
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import dagger.hilt.android.qualifiers.ApplicationContext
 
-class AudioRepository @Inject constructor() {
+class AudioRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
     fun getAudios(): Flow<List<AudioModel>> {
-        return AudioDataSource.fetchAudios()
+        return AudioDataSource.fetchAudios(context)
     }
 }

--- a/data/src/main/java/com/puskal/data/source/AudioDataSource.kt
+++ b/data/src/main/java/com/puskal/data/source/AudioDataSource.kt
@@ -1,48 +1,35 @@
 package com.puskal.data.source
 
+import android.content.Context
 import com.puskal.data.model.AudioModel
-import com.puskal.data.source.UsersDataSource.charliePuth
-import com.puskal.data.source.UsersDataSource.kylieJenner
-import com.puskal.data.source.UsersDataSource.duaLipa
-import com.puskal.data.source.UsersDataSource.taylor
+import com.puskal.data.source.UsersDataSource.userList
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlin.random.Random
 
 object AudioDataSource {
-    private val audioList = listOf(
-        AudioModel(
-            audioCoverImage = "cover_1.jpg",
-            isOriginal = true,
-            audioAuthor = charliePuth,
-            numberOfPost = 239000,
-            duration = "02:10",
-            originalVideoUrl = "audio1.mp3"
-        ),
-        AudioModel(
-            audioCoverImage = "cover_2.jpg",
-            isOriginal = true,
-            audioAuthor = kylieJenner,
-            numberOfPost = 42000,
-            duration = "03:20",
-            originalVideoUrl = "audio2.mp3"
-        ),
-        AudioModel(
-            audioCoverImage = "cover_3.jpg",
-            isOriginal = true,
-            audioAuthor = duaLipa,
-            numberOfPost = 120340,
-            duration = "01:45",
-            originalVideoUrl = "audio3.mp3"
-        ),
-        AudioModel(
-            audioCoverImage = "cover_4.jpg",
-            isOriginal = true,
-            audioAuthor = taylor,
-            numberOfPost = 15200,
-            duration = "02:58",
-            originalVideoUrl = "audio4.mp3"
-        )
-    )
 
-    fun fetchAudios(): Flow<List<AudioModel>> = flow { emit(audioList) }
+    fun fetchAudios(context: Context): Flow<List<AudioModel>> = flow {
+        val assets = context.assets
+        val audioFiles = assets.list("audios")?.filter { it.endsWith(".mp3") } ?: emptyList()
+        val covers = assets.list("audios/cover")?.filter { it.endsWith(".jpg") } ?: emptyList()
+
+        val rnd = Random(System.currentTimeMillis())
+        val result = audioFiles.mapIndexed { index, file ->
+            val cover = covers.getOrElse(index) { covers.random(rnd) }
+            val author = userList[index % userList.size]
+            val duration = String.format("%02d:%02d", rnd.nextInt(1, 4), rnd.nextInt(0, 60))
+            val posts = rnd.nextLong(1000, 300000)
+
+            AudioModel(
+                audioCoverImage = cover,
+                isOriginal = true,
+                audioAuthor = author,
+                numberOfPost = posts,
+                duration = duration,
+                originalVideoUrl = file
+            )
+        }
+        emit(result)
+    }
 }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -40,6 +40,11 @@ fun AudioBottomSheet(
     var search by remember { mutableStateOf("") }
     var selectedTab by remember { mutableStateOf(0) }
 
+    val shuffledLists = remember(viewState?.audioFiles) {
+        val list = viewState?.audioFiles ?: emptyList()
+        List(4) { list.shuffled() }
+    }
+
     val context = LocalContext.current
     val exoPlayer = remember { ExoPlayer.Builder(context).build() }
     var playingItem by remember { mutableStateOf<AudioModel?>(null) }
@@ -136,28 +141,27 @@ fun AudioBottomSheet(
             LazyColumn(
                 modifier = Modifier.weight(1f, fill = true)
             ) {
-                viewState?.audioFiles?.let { list ->
-                    items(list) { audio ->
-                        val isPlaying = playingItem == audio
-                        AudioRow(
-                            audio = audio,
-                            isPlaying = isPlaying,
-                            onClick = {
-                                if (isPlaying) {
-                                    exoPlayer.stop()
-                                    playingItem = null
-                                } else {
-                                    exoPlayer.setMediaItem(
-                                        MediaItem.fromUri("asset:///audios/${audio.originalVideoUrl}")
-                                    )
-                                    exoPlayer.prepare()
-                                    exoPlayer.playWhenReady = true
-                                    playingItem = audio
-                                }
+                val list = shuffledLists.getOrNull(selectedTab) ?: emptyList()
+                items(list) { audio ->
+                    val isPlaying = playingItem == audio
+                    AudioRow(
+                        audio = audio,
+                        isPlaying = isPlaying,
+                        onClick = {
+                            if (isPlaying) {
+                                exoPlayer.stop()
+                                playingItem = null
+                            } else {
+                                exoPlayer.setMediaItem(
+                                    MediaItem.fromUri("asset:///audios/${audio.originalVideoUrl}")
+                                )
+                                exoPlayer.prepare()
+                                exoPlayer.playWhenReady = true
+                                playingItem = audio
                             }
-                        )
-                        Divider(thickness = 0.5.dp, color = SeparatorColor)
-                    }
+                        }
+                    )
+                    Divider(thickness = 0.5.dp, color = SeparatorColor)
                 }
             }
 


### PR DESCRIPTION
## Summary
- load audio asset metadata dynamically using `Context.assets`
- inject application `Context` into `AudioRepository`
- display shuffled audio lists for each tab in `AudioBottomSheet`

## Testing
- `./gradlew assembleDebug --dry-run` *(fails: SDK location not found)*
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880dd29c6e0832cae42e1b217460564