### PR TITLE
Fix icons color in AudioBottomSheet

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -222,14 +222,14 @@ private fun AudioRow(
                 Icon(
                     imageVector = Icons.Filled.ContentCut,
                     contentDescription = stringResource(id = R.string.cut),
-                    tint = Color.White
+                    tint = Color.Black
                 )
             }
             IconButton(onClick = { }) {
                 Icon(
                     imageVector = Icons.Outlined.FavoriteBorder,
                     contentDescription = stringResource(id = R.string.favorite),
-                    tint = Color.White
+                    tint = Color.Black
                 )
             }
         }


### PR DESCRIPTION
## Summary
- ensure the cut and favorite icons in `AudioBottomSheet` use black tint

## Testing
- `./gradlew test` *(fails: plugin class not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880de48568c832c9c2938e9de816e6c