### PR TITLE
Adjust spacer margin in AudioBottomSheet

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -67,7 +67,7 @@ fun AudioBottomSheet(
                         .background(color = GrayMainColor, shape = RoundedCornerShape(2.dp))
                 )
             }
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(5.dp))
 
             OutlinedTextField(
                 value = search,


### PR DESCRIPTION
## Summary
- tweak margin above OutlinedTextField in `AudioBottomSheet`

## Testing
- `./gradlew test --no-daemon` *(fails: commons.AndroidCoreLibraryPlugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e1735d9c832ca1b6263a4c058056