### PR TITLE
Implement vertical padding when video edit toolbar expanded

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
@@ -56,9 +56,16 @@ fun VideoEditToolBar(
     }
 
     val baseModifier = modifier.width(96.dp)
+    val columnModifier = if (expanded) {
+        baseModifier
+            .verticalScroll(rememberScrollState())
+            .padding(vertical = 50.dp)
+    } else {
+        baseModifier
+    }
 
     Column(
-        modifier = if (expanded) baseModifier.verticalScroll(rememberScrollState()) else baseModifier,
+        modifier = columnModifier,
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {


### PR DESCRIPTION
## Summary
- update expanded VideoEditToolBar padding to 50dp

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e8dde0ec832c86bfa50dfedc67cb