### PR TITLE
Use AudioFile icon in bottom sheet

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCut
+import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.MediaItem
@@ -140,7 +141,7 @@ fun AudioBottomSheet(
                     modifier = Modifier.padding(end = 16.dp, start = 8.dp)
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.ic_plus),
+                        imageVector = Icons.Filled.AudioFile,
                         contentDescription = null,
                         modifier = Modifier.size(10.dp)
                     )


### PR DESCRIPTION
## Summary
- switch to the Material `AudioFile` icon in `AudioBottomSheet`

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880eb861b74832c834edb5fae55426a