### PR TITLE
Set audio sheet handle color to gray

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -71,7 +71,7 @@ fun AudioBottomSheet(
                 Box(
                     modifier = Modifier
                         .size(width = 36.dp, height = 4.dp)
-                        .background(color = GrayMainColor, shape = RoundedCornerShape(2.dp))
+                        .background(color = Gray, shape = RoundedCornerShape(2.dp))
                 )
             }
             


### PR DESCRIPTION
## Summary
- change the drag handle color above the search text field in `AudioBottomSheet` to use the `Gray` theme color

## Testing
- `./gradlew test --no-daemon` *(fails: AndroidCoreLibraryPlugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880edd50800832ca02ec7ce2e98f28e