### PR TITLE
Adjust audio bottom sheet handle spacing

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -65,7 +65,7 @@ fun AudioBottomSheet(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 4.dp),
+                    .padding(top = 2.dp),
                 contentAlignment = Alignment.Center
             ) {
                 Box(
@@ -75,7 +75,7 @@ fun AudioBottomSheet(
                 )
             }
             
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(2.dp))
 
             OutlinedTextField(
                 value = search,


### PR DESCRIPTION
## Summary
- tweak the top and bottom spacing around the top indicator of `AudioBottomSheet`

## Testing
- `./gradlew test --no-daemon` *(fails: could not finish Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_6880edebe6bc832cb33f853f33840eeb