### PR TITLE
Invert colors for filter bottom sheet

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoFilterBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoFilterBottomSheet.kt
@@ -9,12 +9,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 import com.puskal.cameramedia.edit.VideoFilter
+import com.puskal.theme.White
+import com.puskal.theme.Black
+import com.puskal.theme.Gray
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -23,7 +28,12 @@ fun VideoFilterBottomSheet(
     onSelectFilter: (VideoFilter) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = White,
+        contentColor = Black,
+        dragHandle = { SheetDefaults.DragHandle(color = Gray) }
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/filter/FilterBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/filter/FilterBottomSheet.kt
@@ -4,13 +4,18 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 import com.otaliastudios.cameraview.filter.Filters
+import com.puskal.theme.Black
+import com.puskal.theme.Gray
+import com.puskal.theme.White
 import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -20,7 +25,12 @@ fun FilterBottomSheet(
     onSelectFilter: (Filters) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = White,
+        contentColor = Black,
+        dragHandle = { SheetDefaults.DragHandle(color = Gray) }
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
## Summary
- show filter sheet with white background and black text
- change drag handle color to gray
- apply same styling to video editing filter sheet

## Testing
- `./gradlew help --no-daemon`
- `./gradlew :app:assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ee69f638832cbdf845034cbd11e5