### PR TITLE
Refactor bottom sheets with shared component

### DIFF
--- a/common/composable/src/main/java/com/puskal/composable/TiktokBottomSheet.kt
+++ b/common/composable/src/main/java/com/puskal/composable/TiktokBottomSheet.kt
@@ -1,0 +1,33 @@
+package com.puskal.composable
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetDefaults
+import androidx.compose.material3.ColumnScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.puskal.theme.Black
+import com.puskal.theme.Gray
+import com.puskal.theme.White
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TiktokBottomSheet(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    containerColor: Color = White,
+    contentColor: Color = Black,
+    dragHandleColor: Color = Gray,
+    dragHandle: @Composable (() -> Unit)? = { SheetDefaults.DragHandle(color = dragHandleColor) },
+    content: @Composable ColumnScope.() -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        dragHandle = dragHandle,
+        content = content
+    )
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoFilterBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoFilterBottomSheet.kt
@@ -8,18 +8,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetDefaults
 import androidx.compose.material3.Text
+import com.puskal.composable.TiktokBottomSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.graphics.Color
 import com.puskal.cameramedia.edit.VideoFilter
-import com.puskal.theme.White
-import com.puskal.theme.Black
-import com.puskal.theme.Gray
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -28,12 +23,7 @@ fun VideoFilterBottomSheet(
     onSelectFilter: (VideoFilter) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        containerColor = White,
-        contentColor = Black,
-        dragHandle = { SheetDefaults.DragHandle(color = Gray) }
-    ) {
+    TiktokBottomSheet(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/filter/FilterBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/filter/FilterBottomSheet.kt
@@ -3,19 +3,14 @@ package com.puskal.cameramedia.filter
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetDefaults
 import androidx.compose.material3.Text
+import com.puskal.composable.TiktokBottomSheet
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.graphics.Color
 import com.otaliastudios.cameraview.filter.Filters
-import com.puskal.theme.Black
-import com.puskal.theme.Gray
-import com.puskal.theme.White
 import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -25,12 +20,7 @@ fun FilterBottomSheet(
     onSelectFilter: (Filters) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        containerColor = White,
-        contentColor = Black,
-        dragHandle = { SheetDefaults.DragHandle(color = Gray) }
-    ) {
+    TiktokBottomSheet(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.material3.*
+import com.puskal.composable.TiktokBottomSheet
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,8 +65,9 @@ fun AudioBottomSheet(
         onDispose { exoPlayer.release() }
     }
 
-    ModalBottomSheet(onDismissRequest = onDismiss) {
-        Column(modifier = Modifier.fillMaxWidth()) {
+    TiktokBottomSheet(
+        onDismissRequest = onDismiss,
+        dragHandle = {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -78,7 +80,9 @@ fun AudioBottomSheet(
                         .background(color = Gray, shape = RoundedCornerShape(2.dp))
                 )
             }
-            
+        }
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
             Spacer(modifier = Modifier.height(2.dp))
 
             OutlinedTextField(


### PR DESCRIPTION
## Summary
- create `TiktokBottomSheet` composable in `common` module
- use `TiktokBottomSheet` in camera media bottom sheets

## Testing
- `./gradlew test` *(fails: command timed out or environment lacks Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6880f0eda31c832c80433ac86f0dce6e