### PR TITLE
Add post video screen after video edit

### DIFF
--- a/common/theme/src/main/res/values/strings.xml
+++ b/common/theme/src/main/res/values/strings.xml
@@ -142,4 +142,10 @@
     <string name="favorites">Favorites</string>
     <string name="used">Used</string>
 
+    <string name="friend_daily">Friend Daily</string>
+    <string name="publish">Publish</string>
+    <string name="location">Location</string>
+    <string name="add_labels">Add labels</string>
+    <string name="private_public">Private / Public</string>
+
 </resources>

--- a/core/src/main/java/com/puskal/core/DestinationRoute.kt
+++ b/core/src/main/java/com/puskal/core/DestinationRoute.kt
@@ -27,6 +27,9 @@ object DestinationRoute {
     const val VIDEO_TRIM_ROUTE = "video_trim_route"
     const val FORMATTED_VIDEO_TRIM_ROUTE = "$VIDEO_TRIM_ROUTE/{${PassedKey.VIDEO_URI}}"
 
+    const val POST_VIDEO_ROUTE = "post_video_route"
+    const val FORMATTED_POST_VIDEO_ROUTE = "$POST_VIDEO_ROUTE/{${PassedKey.VIDEO_URI}}"
+
     const val AUTHENTICATION_ROUTE = "authentication_route"
     const val LOGIN_OR_SIGNUP_WITH_PHONE_EMAIL_ROUTE = "login_signup_phone_email_route"
 

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/CameraMediaNavigation.kt
@@ -13,9 +13,11 @@ import androidx.compose.runtime.getValue
 import com.puskal.core.DestinationRoute
 import com.puskal.core.DestinationRoute.FORMATTED_VIDEO_EDIT_ROUTE
 import com.puskal.core.DestinationRoute.FORMATTED_VIDEO_TRIM_ROUTE
+import com.puskal.core.DestinationRoute.FORMATTED_POST_VIDEO_ROUTE
 import com.puskal.core.DestinationRoute.PassedKey
 import com.puskal.cameramedia.edit.VideoEditScreen
 import com.puskal.cameramedia.edit.VideoTrimScreen
+import com.puskal.cameramedia.post.PostVideoScreen
 
 /**
  * Created by Puskal Khadka on 4/2/2023.
@@ -52,7 +54,12 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
             onClickAddSound = {
                 navController.navigate(DestinationRoute.CHOOSE_SOUND_ROUTE)
             },
-            enableFilters = true
+            enableFilters = true,
+            onClickNext = { encoded ->
+                navController.navigate(
+                    DestinationRoute.POST_VIDEO_ROUTE + "/" + Uri.encode(encoded)
+                )
+            }
         )
     }
 
@@ -71,6 +78,20 @@ fun NavGraphBuilder.cameraMediaNavGraph(navController: NavController) {
                 navController.navigateUp()
             },
             onAddSound = { navController.navigate(DestinationRoute.CHOOSE_SOUND_ROUTE) }
+        )
+    }
+
+    composable(
+        route = FORMATTED_POST_VIDEO_ROUTE,
+        arguments = listOf(navArgument(PassedKey.VIDEO_URI) { type = NavType.StringType })
+    ) { backStackEntry ->
+        val uri = backStackEntry.arguments
+            ?.getString(PassedKey.VIDEO_URI)
+            ?.let { Uri.decode(it) } ?: ""
+        PostVideoScreen(
+            videoUri = uri,
+            onBack = { navController.navigateUp() },
+            onPublish = { navController.navigateUp() }
         )
     }
 }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.*
@@ -19,6 +20,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import com.puskal.cameramedia.MusicBarLayout
+import com.puskal.composable.CustomButton
 import com.puskal.theme.R
 import com.puskal.theme.TikTokTheme
 import com.puskal.theme.White
@@ -33,10 +35,30 @@ fun VideoEditScreen(
     onClickBack: () -> Unit,
     onTrimVideo: (String) -> Unit = {},
     onClickAddSound: () -> Unit = {},
-    enableFilters: Boolean = false
+    enableFilters: Boolean = false,
+    onClickNext: (String) -> Unit = {}
 ) {
     TikTokTheme(darkTheme = true) {
-        Scaffold { padding ->
+        Scaffold(
+            bottomBar = {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    CustomButton(
+                        buttonText = stringResource(id = R.string.friend_daily),
+                        modifier = Modifier.weight(1f)
+                    ) {}
+                    Spacer(modifier = Modifier.width(12.dp))
+                    CustomButton(
+                        buttonText = stringResource(id = R.string.next),
+                        modifier = Modifier.weight(1f)
+                    ) { onClickNext(videoUri) }
+                }
+            }
+        ) { padding ->
             val context = LocalContext.current
 
             /*************** STATE *****************/

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/post/PostVideoScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/post/PostVideoScreen.kt
@@ -1,0 +1,87 @@
+package com.puskal.cameramedia.post
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.puskal.composable.TopBar
+import com.puskal.theme.R
+import com.puskal.theme.TikTokTheme
+import com.puskal.theme.White
+
+@Composable
+fun PostVideoScreen(
+    videoUri: String,
+    onBack: () -> Unit,
+    onPublish: () -> Unit = {},
+    onFriendDaily: () -> Unit = {}
+) {
+    TikTokTheme(darkTheme = true) {
+        Scaffold(
+            topBar = { TopBar { onBack() } },
+            bottomBar = {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    IconButton(onClick = onFriendDaily) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_friends),
+                            contentDescription = null,
+                            tint = White
+                        )
+                    }
+                    IconButton(onClick = onPublish) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_add),
+                            contentDescription = null,
+                            tint = White
+                        )
+                    }
+                }
+            }
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                AsyncImage(
+                    model = videoUri,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .width(200.dp)
+                        .height(400.dp)
+                )
+                val desc = remember { mutableStateOf("") }
+                OutlinedTextField(
+                    value = desc.value,
+                    onValueChange = { desc.value = it },
+                    placeholder = { Text(text = "Description") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                )
+                Text(text = "#topic    @friend", modifier = Modifier.padding(16.dp))
+                Text(text = stringResource(id = R.string.location), modifier = Modifier.padding(16.dp))
+                Text(text = stringResource(id = R.string.add_labels), modifier = Modifier.padding(16.dp))
+                Text(text = stringResource(id = R.string.private_public), modifier = Modifier.padding(16.dp))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PostVideoScreen` with basic UI elements
- add bottom action bar in `VideoEditScreen` to navigate forward
- define POST_VIDEO navigation route and hook into graph
- extend strings with new labels

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f5aafde0832c903fe89c365f2c83