### PR TITLE
Fix drag handle compile issue

### DIFF
--- a/common/composable/src/main/java/com/puskal/composable/TiktokBottomSheet.kt
+++ b/common/composable/src/main/java/com/puskal/composable/TiktokBottomSheet.kt
@@ -2,11 +2,16 @@ package com.puskal.composable
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetDefaults
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import com.puskal.theme.Black
 import com.puskal.theme.Gray
 import com.puskal.theme.White
@@ -19,7 +24,7 @@ fun TiktokBottomSheet(
     containerColor: Color = White,
     contentColor: Color = Black,
     dragHandleColor: Color = Gray,
-    dragHandle: @Composable (() -> Unit)? = { SheetDefaults.DragHandle(color = dragHandleColor) },
+    dragHandle: @Composable (() -> Unit)? = { DefaultDragHandle(color = dragHandleColor) },
     content: @Composable ColumnScope.() -> Unit
 ) {
     ModalBottomSheet(
@@ -29,5 +34,15 @@ fun TiktokBottomSheet(
         contentColor = contentColor,
         dragHandle = dragHandle,
         content = content
+    )
+}
+
+@Composable
+private fun DefaultDragHandle(color: Color) {
+    Box(
+        modifier = Modifier
+            .padding(vertical = 8.dp)
+            .size(width = 32.dp, height = 4.dp)
+            .background(color = color, shape = RoundedCornerShape(2.dp))
     )
 }


### PR DESCRIPTION
## Summary
- replace SheetDefaults reference in `TiktokBottomSheet` with an internal `DefaultDragHandle`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880fe21a230832ca6e21b4ecb2267e4