### PR TITLE
Fix centering for VideoEditScreen 'see more' text

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditToolBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -90,7 +91,9 @@ fun VideoEditToolBar(
                 Text(
                     text = stringResource(id = tool.title),
                     style = MaterialTheme.typography.labelSmall,
-                    color = Color.White
+                    color = Color.White,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
                 )
             }
         }
@@ -115,7 +118,9 @@ fun VideoEditToolBar(
                     Text(
                         text = stringResource(id = feature.title),
                         style = MaterialTheme.typography.labelSmall,
-                        color = Color.White
+                        color = Color.White,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- center the 'see more' label under the VideoEdit toolbar icon

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818ab8548c832cbfb88af96d3204e2