### PR TITLE
Add rounded button for video edit screen

### DIFF
--- a/common/composable/src/main/java/com/puskal/composable/RoundedButton.kt
+++ b/common/composable/src/main/java/com/puskal/composable/RoundedButton.kt
@@ -1,0 +1,24 @@
+package com.puskal.composable
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * A convenience wrapper around [CustomButton] that uses a large rounded shape.
+ */
+@Composable
+fun RoundedButton(
+    modifier: Modifier = Modifier,
+    buttonText: String,
+    onClickButton: () -> Unit,
+) {
+    CustomButton(
+        modifier = modifier,
+        buttonText = buttonText,
+        shape = RoundedCornerShape(percent = 50),
+        style = MaterialTheme.typography.labelLarge,
+        onClickButton = onClickButton
+    )
+}

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -20,7 +20,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import com.puskal.cameramedia.MusicBarLayout
-import com.puskal.composable.CustomButton
+import com.puskal.composable.RoundedButton
 import com.puskal.theme.R
 import com.puskal.theme.TikTokTheme
 import com.puskal.theme.White
@@ -47,12 +47,12 @@ fun VideoEditScreen(
                         .padding(16.dp),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    CustomButton(
+                    RoundedButton(
                         buttonText = stringResource(id = R.string.friend_daily),
                         modifier = Modifier.weight(1f)
                     ) {}
                     Spacer(modifier = Modifier.width(12.dp))
-                    CustomButton(
+                    RoundedButton(
                         buttonText = stringResource(id = R.string.next),
                         modifier = Modifier.weight(1f)
                     ) { onClickNext(videoUri) }


### PR DESCRIPTION
## Summary
- add a RoundedButton composable for consistent rounded styles
- use RoundedButton on VideoEditScreen bottom bar

## Testing
- `./gradlew build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818b061d9c832c88b0b0a6c953d84d