### PR TITLE
Gray Friend Daily Button

### DIFF
--- a/common/composable/src/main/java/com/puskal/composable/RoundedButton.kt
+++ b/common/composable/src/main/java/com/puskal/composable/RoundedButton.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 
 /**
  * A convenience wrapper around [CustomButton] that uses a large rounded shape.
@@ -12,6 +13,7 @@ import androidx.compose.ui.Modifier
 fun RoundedButton(
     modifier: Modifier = Modifier,
     buttonText: String,
+    containerColor: Color = MaterialTheme.colorScheme.primary,
     onClickButton: () -> Unit,
 ) {
     CustomButton(
@@ -19,6 +21,7 @@ fun RoundedButton(
         buttonText = buttonText,
         shape = RoundedCornerShape(percent = 50),
         style = MaterialTheme.typography.labelLarge,
+        containerColor = containerColor,
         onClickButton = onClickButton
     )
 }

--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/edit/VideoEditScreen.kt
@@ -24,6 +24,7 @@ import com.puskal.composable.RoundedButton
 import com.puskal.theme.R
 import com.puskal.theme.TikTokTheme
 import com.puskal.theme.White
+import com.puskal.theme.GrayMainColor
 
 private const val TAG = "VideoEditScreen"
 
@@ -49,7 +50,8 @@ fun VideoEditScreen(
                 ) {
                     RoundedButton(
                         buttonText = stringResource(id = R.string.friend_daily),
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
+                        containerColor = GrayMainColor
                     ) {}
                     Spacer(modifier = Modifier.width(12.dp))
                     RoundedButton(


### PR DESCRIPTION
## Summary
- allow customizing RoundedButton background color
- make the "Friend Daily" button gray in VideoEditScreen

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818d98f508832ca1e7770a65148fe5