### PR TITLE
Adjust audio sheet layout

### DIFF
--- a/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
+++ b/feature/cameramedia/src/main/java/com/puskal/cameramedia/sound/AudioBottomSheet.kt
@@ -165,7 +165,9 @@ fun AudioBottomSheet(
             Spacer(modifier = Modifier.height(8.dp))
 
             LazyColumn(
-                modifier = Modifier.weight(1f, fill = true),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
                 contentPadding = PaddingValues(bottom = 56.dp)
             ) {
                 val list = shuffledLists.getOrNull(selectedTab) ?: emptyList()


### PR DESCRIPTION
## Summary
- keep bottom actions visible by default in `AudioBottomSheet`
- limit audio list height to 100dp so it doesn't hide actions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881c25d30c8832c80975837f6b2e3c4